### PR TITLE
fix(config): reject unsupported env placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ MCPorter reads project and user config, then imports MCP servers from Cursor, Cl
 }
 ```
 
-Config files accept JSONC, environment placeholders, HTTP and stdio definitions, OAuth settings, tool filters, and lifecycle policy. The [configuration guide](docs/config.md) defines precedence and the full schema; the [import reference](docs/import.md) lists every discovered client format.
+Config files accept JSONC, environment placeholders (`${VAR}`, `${VAR:-fallback}`, or whole-value `$env:VAR`), HTTP and stdio definitions, OAuth settings, tool filters, and lifecycle policy. The [configuration guide](docs/config.md) defines precedence and the full schema; the [import reference](docs/import.md) lists every discovered client format. The `${env:VAR}` form used by some MCP clients is not supported; mcporter rejects it with the accepted alternatives instead of sending it literally.
 
 Chrome DevTools definitions using `--autoConnect` can control Chrome through a paired [OpenClaw extension relay](docs/daemon.md#chrome-devtools-through-the-openclaw-extension-relay). MCPorter discovers OpenClaw's active extension relay endpoint, while preserving an explicit `MCPORTER_CHROME_DEVTOOLS_RELAY_URL` override and the legacy `127.0.0.1:18799` fallback. It uses Browser Relay Authentication v2 over one retained loopback socket, keeps the host key out of the network and child process, and gives `chrome-devtools-mcp` a credential-free loopback URL plus ephemeral authorization through an OS-protected preload handoff. Old relay authentication is never retried. Routing defaults to `prefer`, which may fall back only to Chrome's original auto-connect path; `require` fails closed and `off` keeps original auto-connect.
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -25,6 +25,7 @@ Set `"imports": []` when you want to disable auto-merging entirely, or supply a 
   - `{ "servers": { ... } }` (older VS Code previews).
 - **TOML container**: Codex uses TOML files with `[mcp_servers.<name>]` tables. Only `.codex/config.toml` is recognized.
 - **Shared fields**: We convert JSON/TOML entries into mcporter’s schema, honoring `baseUrl`, `command` (string or array), `args`, `headers`, `env`, `bearerToken`, `bearerTokenEnv`, `description`, `tokenCacheDir`, `clientName`, `oauthClientId`, `oauthClientSecretEnv`, `oauthTokenEndpointAuthMethod`, and `auth`. Extra properties are ignored.
+- **Environment placeholders**: Imported `headers` and `env` values support `${VAR}`, `${VAR:-fallback}`, and whole-value `$env:VAR`. The `${env:VAR}` form used by some clients is not expanded; mcporter reports the supported alternatives before starting a request or child process.
 
 ## Import Support Matrix
 

--- a/mcporter.schema.json
+++ b/mcporter.schema.json
@@ -64,7 +64,7 @@
             "type": "string"
           },
           "headers": {
-            "description": "HTTP headers for requests. Supports ${VAR}, ${VAR:-fallback}, and $env:VAR placeholders",
+            "description": "HTTP headers for requests. Supports ${VAR}, ${VAR:-fallback}, and whole-value $env:VAR placeholders",
             "type": "object",
             "propertyNames": {
               "type": "string"
@@ -74,7 +74,7 @@
             }
           },
           "env": {
-            "description": "Environment variables for stdio commands. Supports ${VAR} and ${VAR:-fallback} placeholders",
+            "description": "Environment variables for stdio commands. Supports ${VAR}, ${VAR:-fallback}, and whole-value $env:VAR placeholders",
             "type": "object",
             "propertyNames": {
               "type": "string"

--- a/src/cli/adhoc-help.ts
+++ b/src/cli/adhoc-help.ts
@@ -1,10 +1,16 @@
 export const ADHOC_SERVER_HELP_ENTRIES = [
   { flag: '--http-url <url>', description: 'Register an HTTP server for this run.' },
   { flag: '--allow-http', description: 'Permit plain http:// URLs with --http-url.' },
-  { flag: '--header KEY=value', description: 'Attach HTTP headers (repeatable).' },
+  {
+    flag: '--header KEY=value',
+    description: 'Attach HTTP headers; values support ${VAR}, ${VAR:-fallback}, or whole-value $env:VAR.',
+  },
   { flag: '--stdio <command>', description: 'Run a stdio MCP server (repeat --stdio-arg for args).' },
   { flag: '--stdio-arg <value>', description: 'Append args to the stdio command (repeatable).' },
-  { flag: '--env KEY=value', description: 'Inject env vars for stdio servers (repeatable).' },
+  {
+    flag: '--env KEY=value',
+    description: 'Inject stdio env vars; values support ${VAR}, ${VAR:-fallback}, or whole-value $env:VAR.',
+  },
   { flag: '--cwd <path>', description: 'Working directory for stdio servers.' },
   { flag: '--name <value>', description: 'Override the display name for ad-hoc servers.' },
   { flag: '--description <text>', description: 'Override the description for ad-hoc servers.' },

--- a/src/cli/config/help.ts
+++ b/src/cli/config/help.ts
@@ -48,8 +48,14 @@ export const CONFIG_HELP_ENTRIES: Record<ConfigSubcommand, ConfigHelpEntry> = {
       { flag: '--transport <http|sse|stdio>', description: 'Force a specific transport (validates target).' },
       { flag: '--arg <value>', description: 'Pass through additional stdio arguments (repeatable).' },
       { flag: '--description <text>', description: 'Set a human-friendly summary.' },
-      { flag: '--env KEY=value', description: 'Attach environment variables (repeatable).' },
-      { flag: '--header KEY=value', description: 'Attach HTTP headers (repeatable).' },
+      {
+        flag: '--env KEY=value',
+        description: 'Attach environment variables; values support ${VAR}, ${VAR:-fallback}, or whole-value $env:VAR.',
+      },
+      {
+        flag: '--header KEY=value',
+        description: 'Attach HTTP headers; values support ${VAR}, ${VAR:-fallback}, or whole-value $env:VAR.',
+      },
       { flag: '--token-cache-dir <path>', description: 'Override where OAuth tokens are persisted.' },
       { flag: '--client-name <name>', description: 'Customize the OAuth client identifier.' },
       { flag: '--oauth-client-id <id>', description: 'Use a pre-registered OAuth client id.' },

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -114,11 +114,13 @@ export const RawEntrySchema = z
     headers: z
       .record(z.string(), z.string())
       .optional()
-      .describe('HTTP headers for requests. Supports ${VAR}, ${VAR:-fallback}, and $env:VAR placeholders'),
+      .describe('HTTP headers for requests. Supports ${VAR}, ${VAR:-fallback}, and whole-value $env:VAR placeholders'),
     env: z
       .record(z.string(), z.string())
       .optional()
-      .describe('Environment variables for stdio commands. Supports ${VAR} and ${VAR:-fallback} placeholders'),
+      .describe(
+        'Environment variables for stdio commands. Supports ${VAR}, ${VAR:-fallback}, and whole-value $env:VAR placeholders'
+      ),
     auth: z.string().optional().describe('Authentication method (e.g., "oauth")'),
     tokenCacheDir: z.string().optional().describe('Directory for caching OAuth tokens (camelCase)'),
     token_cache_dir: z.string().optional().describe('Directory for caching OAuth tokens (snake_case)'),

--- a/src/env.ts
+++ b/src/env.ts
@@ -107,6 +107,7 @@ export async function withEnvOverrides<T>(
 
   const applied: string[] = [];
   for (const [key, rawValue] of Object.entries(envOverrides)) {
+    rejectUnsupportedBracedEnvPlaceholder(rawValue);
     if (process.env[key]) {
       continue;
     }

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 const ENV_DEFAULT_PATTERN = /^\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-|:|-)?([^}]*)\}$/;
 const ENV_INTERPOLATION_PATTERN = /\\?\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}/g;
+const UNSUPPORTED_BRACED_ENV_PATTERN = /\$\{env:[^}]*\}/;
 const ENV_DIRECT_PREFIX = '$env:';
 
 // expandHome replaces a leading '~' with the current user's home directory.
@@ -25,6 +26,7 @@ export function resolveEnvValue(raw: unknown, env: NodeJS.ProcessEnv = process.e
   if (typeof raw !== 'string') {
     return String(raw);
   }
+  rejectUnsupportedBracedEnvPlaceholder(raw);
 
   const match = ENV_DEFAULT_PATTERN.exec(raw);
   if (match) {
@@ -49,6 +51,8 @@ export function resolveEnvValue(raw: unknown, env: NodeJS.ProcessEnv = process.e
 
 // resolveEnvPlaceholders replaces ${VAR} or $env:VAR references using the supplied environment.
 export function resolveEnvPlaceholders(value: string, env: NodeJS.ProcessEnv = process.env): string {
+  rejectUnsupportedBracedEnvPlaceholder(value);
+
   if (value.startsWith(ENV_DIRECT_PREFIX)) {
     const envName = value.slice(ENV_DIRECT_PREFIX.length);
     const envValue = env[envName];
@@ -80,6 +84,16 @@ export function resolveEnvPlaceholders(value: string, env: NodeJS.ProcessEnv = p
   }
 
   return replaced;
+}
+
+function rejectUnsupportedBracedEnvPlaceholder(value: string): void {
+  const unsupported = UNSUPPORTED_BRACED_ENV_PATTERN.exec(value)?.[0];
+  if (!unsupported) {
+    return;
+  }
+  throw new Error(
+    `Unsupported environment placeholder '${unsupported}'. Use '\${VAR}', '\${VAR:-fallback}', or whole-value '$env:VAR'.`
+  );
 }
 
 // withEnvOverrides temporarily populates process.env keys while executing the provided callback.

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,6 +1,6 @@
 import { resolveEnvPlaceholders } from '../env.js';
 
-const ENV_PLACEHOLDER_PATTERN = /\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}/;
+const ENV_PLACEHOLDER_PATTERN = /\$\{(?:env:[^}]*|[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?)\}/;
 
 export function resolveCommandArgument(value: string, env: NodeJS.ProcessEnv = process.env): string {
   if (!value) {

--- a/tests/config-help.test.ts
+++ b/tests/config-help.test.ts
@@ -13,7 +13,7 @@ describe('config help', () => {
 
   it.each([
     [undefined, ['mcporter config', 'Commands', 'config add', 'detailed flag info']],
-    ['ADD', ['mcporter config add', 'Usage', '--oauth-client-secret-env', 'Examples']],
+    ['ADD', ['mcporter config add', 'Usage', '--oauth-client-secret-env', '${VAR:-fallback}', '$env:VAR', 'Examples']],
     ['remove', ['mcporter config remove', 'Usage', 'config remove linear']],
     ['unknown', ["Unknown config subcommand 'unknown'", 'list, get, add']],
   ])('prints focused help for %s', (subcommand, expectedFragments) => {

--- a/tests/env-and-daemon-utils.test.ts
+++ b/tests/env-and-daemon-utils.test.ts
@@ -42,6 +42,16 @@ describe('environment helpers', () => {
     expect(() => resolveEnvPlaceholders('${MISSING_Z}-${MISSING_A}')).toThrow('MISSING_A, MISSING_Z');
   });
 
+  it('rejects unsupported braced env placeholders with supported alternatives', () => {
+    expect(() => resolveEnvPlaceholders('Bearer ${env:MCPORTER_TOKEN}', { MCPORTER_TOKEN: 'secret' })).toThrow(
+      "Unsupported environment placeholder '${env:MCPORTER_TOKEN}'. Use '${VAR}', '${VAR:-fallback}', or whole-value '$env:VAR'."
+    );
+    expect(() => resolveEnvValue('${env:MCPORTER_TOKEN}', { MCPORTER_TOKEN: 'secret' })).toThrow(
+      'Unsupported environment placeholder'
+    );
+    expect(resolveEnvPlaceholders('Bearer literal env:MCPORTER_TOKEN')).toBe('Bearer literal env:MCPORTER_TOKEN');
+  });
+
   it('applies only absent non-empty overrides and always restores them', async () => {
     process.env.MCPORTER_EXISTING = 'original';
     await expect(

--- a/tests/env-and-daemon-utils.test.ts
+++ b/tests/env-and-daemon-utils.test.ts
@@ -68,6 +68,14 @@ describe('environment helpers', () => {
     expect(process.env.MCPORTER_TEMP).toBeUndefined();
     await expect(withEnvOverrides(undefined, async () => 'done')).resolves.toBe('done');
   });
+
+  it('rejects unsupported placeholders before inherited env precedence', async () => {
+    process.env.MCPORTER_EXISTING = 'original';
+
+    await expect(
+      withEnvOverrides({ MCPORTER_EXISTING: '${env:MCPORTER_EXISTING}' }, async () => 'unreachable')
+    ).rejects.toThrow("Unsupported environment placeholder '${env:MCPORTER_EXISTING}'");
+  });
 });
 
 describe('daemon request utilities', () => {

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { loadServerDefinitions } from '../src/config.js';
 import { resolveEnvPlaceholders, resolveEnvValue, withEnvOverrides } from '../src/env.js';
+import { createRuntime } from '../src/runtime.js';
 import { resolveCommandArgument } from '../src/runtime/utils.js';
 
 const FIXTURE_PATH = path.resolve(__dirname, 'fixtures', 'mcporter.json');
@@ -105,5 +106,20 @@ describe('command argument interpolation', () => {
     const value = '--browserUrl';
     const result = resolveCommandArgument(value);
     expect(result).toBe(value);
+  });
+
+  it('rejects unsupported placeholders in direct runtime definitions before launch', async () => {
+    const runtime = await createRuntime({
+      servers: [
+        {
+          name: 'invalid-command',
+          command: { kind: 'stdio', command: '${env:MCPORTER_COMMAND}', args: [], cwd: process.cwd() },
+        },
+      ],
+    });
+
+    await expect(runtime.connect('invalid-command')).rejects.toThrow(
+      "Unsupported environment placeholder '${env:MCPORTER_COMMAND}'"
+    );
   });
 });


### PR DESCRIPTION
Closes #323

## Summary

- reject unsupported `${env:VAR}` placeholders before HTTP requests or stdio process launches, including inherited environment keys and direct SDK runtime definitions
- show the accepted `${VAR}`, `${VAR:-fallback}`, and whole-value `$env:VAR` forms in CLI help, the packaged README, import guidance, and generated schema
- preserve the existing placeholder grammar and literal non-placeholder text

## Behavior proof

On current main, resolving `Bearer ${env:MCPORTER_TEST_TOKEN}` with `MCPORTER_TEST_TOKEN` set returned the same literal string, allowing it to reach an authorization header unchanged. A whole-value `${env:MCPORTER_TEST_TOKEN}` also entered the legacy default parser instead of reporting unsupported syntax.

After the fix, two isolated configurations were exercised through the built CLI. Paths are redacted below. The HTTP configuration failed while resolving its header, before any request:

```text
$ node dist/cli.js list invalid-header --config <redacted-config>
invalid-header
  tools unavailable ... HTTP http://127.0.0.1:9/mcp

  Tools: <unavailable>
  Reason: Failed to resolve header 'Authorization' for server 'invalid-header': Unsupported environment placeholder '${env:MCPORTER_PROOF}'. Use '${VAR}', '${VAR:-fallback}', or whole-value '$env:VAR'.
```

The stdio configuration used inherited `PATH` and a child command that would create a sentinel if launched. It failed on the configured value before inherited-key precedence, and the sentinel remained absent:

```text
$ env PATH="$PATH" node dist/cli.js list invalid-stdio --config <redacted-config>
invalid-stdio
  tools unavailable ... STDIO node -e <sentinel writer>

  Tools: <unavailable>
  Reason: Unsupported environment placeholder '${env:PATH}'. Use '${VAR}', '${VAR:-fallback}', or whole-value '$env:VAR'.
$ test ! -e "$sentinel"
$ echo $?
0
```

A direct `createRuntime({ servers })` regression also supplies `${env:MCPORTER_COMMAND}` as the stdio executable and verifies that `runtime.connect()` returns the same corrective error before transport creation.

## Validation

```text
pnpm exec vitest run tests/runtime-utils.test.ts tests/env-and-daemon-utils.test.ts tests/runtime.test.ts tests/config-help.test.ts
pnpm docs:list
pnpm check
pnpm test
pnpm docs:site
git diff --check
```

Focused regression coverage passed with 4 files and 29 tests. The full suite passed with 194 files and 1,639 tests; 4 files and 26 tests were skipped by the existing suite configuration. Documentation listing, formatting, lint, type checking, the build, the documentation site build, and the diff check also passed on Node.js 24.19.0 with pnpm 10.34.5.

## Limitations

This rejects `${env:VAR}` with corrective guidance rather than translating it. Supported placeholder behavior is unchanged, and no live provider credentials are required for this parser and help-surface fix.

Disclosure: AI was used to understand the codebase and review the fix.
