### PR TITLE
test(oauth): cover stored-credential validation guards

### DIFF
--- a/tests/oauth-credential-validation.test.ts
+++ b/tests/oauth-credential-validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { isStoredOAuthClientInformation, isStoredOAuthTokens } from '../src/oauth-credential-validation.js';
+
+function validTokens(overrides: Record<string, unknown> = {}): unknown {
+  return { access_token: 'tok', token_type: 'bearer', ...overrides };
+}
+
+describe('isStoredOAuthTokens', () => {
+  it('accepts the minimal required shape', () => {
+    expect(isStoredOAuthTokens(validTokens())).toBe(true);
+  });
+
+  it('accepts every optional field at its valid type', () => {
+    expect(
+      isStoredOAuthTokens(
+        validTokens({
+          refresh_token: 'refresh',
+          scope: 'read write',
+          issuer: 'https://issuer.example',
+          expires_in: 3600,
+          expires_at: 1_700_000_000,
+          expiresAt: 1_700_000_000,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects non-record inputs', () => {
+    expect(isStoredOAuthTokens(null)).toBe(false);
+    expect(isStoredOAuthTokens(undefined)).toBe(false);
+    expect(isStoredOAuthTokens('bearer')).toBe(false);
+    expect(isStoredOAuthTokens(42)).toBe(false);
+    expect(isStoredOAuthTokens(['access_token'])).toBe(false);
+  });
+
+  it('rejects a missing, empty, or non-string access_token', () => {
+    expect(isStoredOAuthTokens({ token_type: 'bearer' })).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ access_token: '' }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ access_token: 123 }))).toBe(false);
+  });
+
+  it('rejects a missing, empty, or non-string token_type', () => {
+    expect(isStoredOAuthTokens({ access_token: 'tok' })).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ token_type: '' }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ token_type: 123 }))).toBe(false);
+  });
+
+  it('rejects an optional string field carrying a non-string value', () => {
+    expect(isStoredOAuthTokens(validTokens({ refresh_token: 1 }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ scope: 1 }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ issuer: 1 }))).toBe(false);
+  });
+
+  it('rejects an optional numeric field carrying a non-finite or non-number value', () => {
+    expect(isStoredOAuthTokens(validTokens({ expires_in: Number.NaN }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ expires_in: Number.POSITIVE_INFINITY }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ expires_in: '3600' }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ expires_at: Number.NaN }))).toBe(false);
+    expect(isStoredOAuthTokens(validTokens({ expiresAt: Number.NaN }))).toBe(false);
+  });
+});
+
+describe('isStoredOAuthClientInformation', () => {
+  it('rejects non-record inputs', () => {
+    expect(isStoredOAuthClientInformation(null)).toBe(false);
+    expect(isStoredOAuthClientInformation('issuer')).toBe(false);
+    expect(isStoredOAuthClientInformation(['issuer'])).toBe(false);
+  });
+
+  it('accepts a record with no issuer or a string issuer', () => {
+    expect(isStoredOAuthClientInformation({})).toBe(true);
+    expect(isStoredOAuthClientInformation({ client_id: 'abc' })).toBe(true);
+    expect(isStoredOAuthClientInformation({ issuer: 'https://issuer.example' })).toBe(true);
+  });
+
+  it('rejects a record whose issuer is present but not a string', () => {
+    expect(isStoredOAuthClientInformation({ issuer: 42 })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`src/oauth-credential-validation.ts` exports the two type-guards that decide whether a **stored** OAuth credential read back from disk is trusted or dropped — `isStoredOAuthTokens` and `isStoredOAuthClientInformation` — and the module shipped with **no direct test coverage** (no `tests/oauth-credential-validation.test.ts` on `main`). Both gate real persistence decisions:

- `oauth-persistence-stores.ts:146` / `:198` — `readTokens()` / `readClientInfo()` return the stored value **only if** the guard passes, otherwise `undefined` (drop-and-re-auth).
- `oauth-vault.ts:247` / `:248` — a snapshot persists `tokens` / `clientInfo` with a hidden generation marker **only if** the guard passes.

The guards carry a subtle contract a plausible refactor could silently break:

- `isStoredOAuthTokens` requires a **non-empty** `access_token` string **and** a **non-empty** `token_type` string; `refresh_token`/`scope`/`issuer` must each be absent-or-string; `expires_in`/`expires_at`/`expiresAt` must each be absent-or-a-finite-number; a non-record (null, array, primitive) is rejected.
- `isStoredOAuthClientInformation` rejects a non-record and rejects a present-but-non-string `issuer`.

Dropping the empty-string check, the `Number.isFinite` guard, the optional-type checks, or the array/record discrimination would let a malformed credential through (or reject a valid one) with nothing to catch it.

## Why This Change Was Made

Coverage-only. Adds one new file, `tests/oauth-credential-validation.test.ts` (**+79, no production code touched**), pinning both guards' current `main` behavior. The tests import the **real** exported functions and drive them directly — no stubs. No new config, defaults, dependencies, or behavior.

**Not a duplicate of the existing boundary suite (scope note).** `tests/oauth-persistence-stores.test.ts` reaches these guards, but only on the **accept** arm — it stores *valid* tokens and asserts they round-trip (`:37`, `:59`, `:99`), and its "corrupt credential JSON" case (`:71`) writes `'{bad'`, which fails `JSON.parse` in the reader **before** the guard runs, so it never exercises the guards' rejection logic. Every **rejection** branch (empty required string, wrong optional type, non-finite number, non-record, non-string issuer) is unreached by any test at any level. This suite adds exactly those provably-skipped arms — see the mutation evidence below, where the existing boundary suite stays green under guard mutations that this suite catches.

## User Impact

No user-visible or runtime change. For maintainers, the stored-credential validation contract now regresses loudly instead of silently: a future edit that breaks the empty-token gate, an optional-field type check, the finite-number check, or the record/array discrimination will fail this suite.

## Evidence

Linux, Node 22.22, `pnpm install --frozen-lockfile` from source, branched off current `main` (`ae3d900`).

**10/10 pass on clean `main`:**

```console
$ ./node_modules/.bin/vitest run tests/oauth-credential-validation.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**Non-vacuous — the suite bites when the target is mutated** (each mutation applied to `oauth-credential-validation.ts`, suite re-run, then reverted byte-identical):

| Mutation to `oauth-credential-validation.ts` | Result |
| --- | --- |
| `access_token.length > 0` → `>= 0` (accept empty) | 1 fail |
| `token_type.length > 0` → `>= 0` (accept empty) | 1 fail |
| `isRecord` drops `!Array.isArray(value)` | 1 fail |
| `isOptionalString` drops the `=== undefined` arm (require string) | 2 fail |
| `isOptionalFiniteNumber` drops `Number.isFinite` | 1 fail |
| `isStoredOAuthClientInformation` returns `true` after the record check | 1 fail |
| *(reverted — control)* | **10 pass** |

**These regressions are invisible to the existing suite.** Running the current caller/boundary tests (`oauth-persistence-stores`, `oauth-persistence`, `vault-command`, `oauth-session`) under the first, fifth, and third mutations above leaves their pass/fail count **unchanged** — the boundary suite never feeds a parseable-but-invalid credential to the guard, so it cannot catch these. This suite is the only coverage of the rejection contract.

**Format / lint / types clean on the new file:**

```console
$ ./node_modules/.bin/oxfmt --check tests/oauth-credential-validation.test.ts   # All matched files use the correct format.
$ ./node_modules/.bin/oxlint --type-aware --tsconfig tsconfig.json --deny-warnings tests/oauth-credential-validation.test.ts   # exit 0
$ ./node_modules/.bin/tsc --project tsconfig.json --noEmit   # exit 0
```

**Scope note:** one new `*.test.ts` under `tests/`, `+79 / -0`, no production code touched. Same module family as the merged OAuth-helper coverage #246 (token generation) and #281 (client info) — this is the stored-credential validation sibling.

_AI-assisted contribution._

<sub>Opened from an org-owned fork via the API; if GitHub's *Allow edits by maintainers* toggle isn't honored on this PR, a maintainer can still push to the branch or supersede-and-land.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4tqYUv5PvekSPezub8ESs)_