### PR TITLE
fix(generate-cli): emit flag names commander can parse

### DIFF
--- a/src/cli/generate/template.ts
+++ b/src/cli/generate/template.ts
@@ -435,6 +435,13 @@ if (process.env.MCPORTER_DISABLE_AUTORUN !== '1') {
 `;
 }
 
+// Commander stores each option under the camelCase form of its flag, and a schema property
+// name can legally produce a key no property access can spell - `2fa` is stored under `2fa`,
+// and `cmdOpts.2fa` does not parse. Those keys are read through a subscript instead.
+function propertyAccess(target: string, key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? `${target}.${key}` : `${target}[${JSON.stringify(key)}]`;
+}
+
 export function renderToolCommand(
   tool: ToolMetadata,
   defaultTimeout: number,
@@ -463,8 +470,8 @@ export function renderToolCommand(
         .filter(Boolean)
         .map((segment, index) => (index === 0 ? segment : `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`))
         .join('');
-      const source = `cmdOpts.${camelCaseProp}`;
-      return `if (${source} !== undefined) args.${option.property} = ${source};`;
+      const source = propertyAccess('cmdOpts', camelCaseProp);
+      return `if (${source} !== undefined) ${propertyAccess('args', option.property)} = ${source};`;
     })
     .join('\n\t\t');
   const requiredChecks = tool.options
@@ -482,7 +489,7 @@ export function renderToolCommand(
       ? `const missingRequired = [${requiredChecks
           .map(
             ({ option, camelCaseProp }) =>
-              `{ value: cmdOpts.${camelCaseProp}, flag: ${JSON.stringify(`--${option.cliName}`)} }`
+              `{ value: ${propertyAccess('cmdOpts', camelCaseProp)}, flag: ${JSON.stringify(`--${option.cliName}`)} }`
           )
           .join(
             ', '

--- a/src/cli/generate/template.ts
+++ b/src/cli/generate/template.ts
@@ -72,7 +72,7 @@ export function renderTemplate({
   const imports = [
     "import path from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
-    "import { Command } from 'commander';",
+    "import { Command, Option } from 'commander';",
     "import { createGeneratedKeepAliveRuntime, createRuntime, createServerProxy, handleDaemonCli } from 'mcporter';",
     "import { createCallResult } from 'mcporter';",
   ].join('\n');
@@ -218,6 +218,18 @@ function unwrapRawPayload(value: unknown): unknown {
 \t\treturn (value as { raw: unknown }).raw;
 \t}
 \treturn value;
+}
+
+function defineOption(flags: string, description: string, parser?: (value: string) => unknown) {
+\tconst option = new Option(flags, description);
+\tif (parser) {
+\t\toption.argParser(parser);
+\t}
+\t// Flag names come from schema property names, so a leading no- is part of the name.
+\t// Commander would otherwise read it as a negation, store the value under the stripped
+\t// name and default it to true whenever the flag is absent.
+\toption.negate = false;
+\treturn option;
 }
 
 function parseArrayOption(value: string, itemType: 'string' | 'number' | 'boolean' | 'json') {
@@ -525,9 +537,9 @@ ${aliasSnippet ? `\t${aliasSnippet}` : ''}\t.action(async (cmdOpts) => {
 
 function renderOption(optionDoc: ToolOptionDoc): string {
   const parser = optionParser(optionDoc.option);
-  return `\t.option(${JSON.stringify(optionDoc.flagLabel)}, ${JSON.stringify(optionDoc.description)}${
+  return `\t.addOption(defineOption(${JSON.stringify(optionDoc.flagLabel)}, ${JSON.stringify(optionDoc.description)}${
     parser ? `, ${parser}` : ''
-  })`;
+  }))`;
 }
 
 function computeRelativeStdioCwd(definition: ServerDefinition, outputPath?: string): string | null {

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -102,17 +102,20 @@ export function extractOptions(tool: ServerToolInfo): GeneratedOption[] {
   // Flatten schema properties into Commander-friendly option descriptors.
   const properties = record.properties as Record<string, unknown>;
   const requiredList = Array.isArray(record.required) ? (record.required as string[]) : [];
-  return Object.entries(properties).map(([property, descriptor]) => {
+  const entries = Object.entries(properties);
+  const cliNames = assignCliNames(entries.map(([property]) => property));
+  return entries.map(([property, descriptor], index) => {
+    const cliName = cliNames[index] as string;
     const type = inferType(descriptor);
     const arrayItemType = type === 'array' ? inferArrayItemType(descriptor) : undefined;
     const enumValues = getEnumValues(descriptor);
     const defaultValue = getDescriptorDefault(descriptor);
     const formatInfo = getDescriptorFormatHint(descriptor);
-    const placeholder = buildPlaceholder(property, type, enumValues, formatInfo?.slug);
+    const placeholder = buildPlaceholder(cliName, type, enumValues, formatInfo?.slug);
     const exampleValue = buildExampleValue(property, type, enumValues, defaultValue, arrayItemType);
     return {
       property,
-      cliName: toCliOption(property),
+      cliName,
       description: getDescriptorDescription(descriptor),
       required: requiredList.includes(property),
       type,
@@ -123,6 +126,26 @@ export function extractOptions(tool: ServerToolInfo): GeneratedOption[] {
       defaultValue,
       formatHint: formatInfo?.display,
     };
+  });
+}
+
+// Two legal property spellings can normalize onto one flag - `Query` beside `query`, or
+// `no_cache` beside `noCache` - and commander would then declare that flag twice and read one
+// value into both arguments. Schema order keeps the plain flag; a later property takes the first
+// suffix no other property claims.
+function assignCliNames(properties: string[]): string[] {
+  const natural = properties.map((property) => toCliOption(property));
+  const claimed = new Set(natural);
+  const used = new Set<string>();
+  return natural.map((base) => {
+    let name = base;
+    let suffix = 2;
+    while (used.has(name) || (name !== base && claimed.has(name))) {
+      name = `${base}-${suffix}`;
+      suffix += 1;
+    }
+    used.add(name);
+    return name;
   });
 }
 

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -457,9 +457,12 @@ export function toCliOption(property: string): string {
   const normalized = property
     .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
     .replace(/_/g, '-')
-    // A leading uppercase letter or underscore would otherwise produce `---flag`, which
-    // commander rejects while the generated command is being built.
-    .replace(/^-+/, '');
+    // Commander derives an option's storage key by splitting the flag on dashes and
+    // upper-casing each segment, so any empty segment - a run of separators in `foo__bar`,
+    // a leading one from `Query`, a trailing one from `foo_` - makes `addOption` throw while
+    // the generated command is being built.
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '');
   // Every character of a property such as `___` normalizes away, and commander rejects the
   // `--` that name would spell. The stem stands in for the whole name, so `assignCliNames`
   // sees it before it hands out suffixes and a schema declaring `option` beside `___` still

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -135,7 +135,7 @@ export function getEnumValues(descriptor: unknown): string[] | undefined {
     const values = record.enum.filter((entry): entry is string => typeof entry === 'string');
     return values.length > 0 ? values : undefined;
   }
-  if (record.type === 'array' && typeof record.items === 'object' && record.items !== null) {
+  if (isArraySchema(record) && typeof record.items === 'object' && record.items !== null) {
     const nested = record.items as Record<string, unknown>;
     if (Array.isArray(nested.enum)) {
       const values = nested.enum.filter((entry): entry is string => typeof entry === 'string');
@@ -340,12 +340,18 @@ export function inferType(descriptor: unknown): GeneratedOption['type'] {
   return 'unknown';
 }
 
+// `type` may be a union such as `["array", "null"]`, so ask inferType instead of comparing the
+// raw value: these container checks have to agree with the type the option is generated with.
+function isArraySchema(record: Record<string, unknown>): boolean {
+  return inferType(record) === 'array';
+}
+
 export function inferArrayItemType(descriptor: unknown): GeneratedOption['arrayItemType'] {
   if (!descriptor || typeof descriptor !== 'object') {
     return 'unknown';
   }
   const record = descriptor as Record<string, unknown>;
-  if (record.type !== 'array' || !record.items || typeof record.items !== 'object') {
+  if (!isArraySchema(record) || !record.items || typeof record.items !== 'object') {
     return 'unknown';
   }
   const items = record.items as Record<string, unknown>;

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -429,15 +429,14 @@ export function toProxyMethodName(toolName: string): string {
 }
 
 export function toCliOption(property: string): string {
-  const flag = property
-    .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
-    .replace(/_/g, '-')
-    // A leading uppercase letter or underscore would otherwise produce `---flag`, which
-    // commander rejects while the generated command is being built.
-    .replace(/^-+/, '');
-  // Commander reads `--no-x` as a negated boolean: it stores the parsed value under `x` and
-  // defaults it to true when the flag is absent, so the generated command would never see it.
-  return flag.startsWith('no-') ? `no${flag.slice(3)}` : flag;
+  return (
+    property
+      .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
+      .replace(/_/g, '-')
+      // A leading uppercase letter or underscore would otherwise produce `---flag`, which
+      // commander rejects while the generated command is being built.
+      .replace(/^-+/, '')
+  );
 }
 
 export const toolsTestHelpers = {

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -129,6 +129,8 @@ export function extractOptions(tool: ServerToolInfo): GeneratedOption[] {
   });
 }
 
+const EMPTY_CLI_OPTION_STEM = 'option';
+
 // Two legal property spellings can normalize onto one flag - `Query` beside `query`, or
 // `no_cache` beside `noCache` - and commander would then declare that flag twice and read one
 // value into both arguments. Schema order keeps the plain flag; a later property takes the first
@@ -452,14 +454,17 @@ export function toProxyMethodName(toolName: string): string {
 }
 
 export function toCliOption(property: string): string {
-  return (
-    property
-      .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
-      .replace(/_/g, '-')
-      // A leading uppercase letter or underscore would otherwise produce `---flag`, which
-      // commander rejects while the generated command is being built.
-      .replace(/^-+/, '')
-  );
+  const normalized = property
+    .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
+    .replace(/_/g, '-')
+    // A leading uppercase letter or underscore would otherwise produce `---flag`, which
+    // commander rejects while the generated command is being built.
+    .replace(/^-+/, '');
+  // Every character of a property such as `___` normalizes away, and commander rejects the
+  // `--` that name would spell. The stem stands in for the whole name, so `assignCliNames`
+  // sees it before it hands out suffixes and a schema declaring `option` beside `___` still
+  // gets two distinct flags.
+  return normalized === '' ? EMPTY_CLI_OPTION_STEM : normalized;
 }
 
 export const toolsTestHelpers = {

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -165,7 +165,7 @@ export function buildPlaceholder(
   enumValues?: string[],
   formatSlug?: string
 ): string {
-  const normalized = property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
+  const normalized = toCliOption(property);
   if (enumValues && enumValues.length > 0) {
     // Enum members can describe an array's items, and the generated parser splits those
     // flags on commas, so keep the multi-value hint next to the choices.
@@ -423,7 +423,15 @@ export function toProxyMethodName(toolName: string): string {
 }
 
 export function toCliOption(property: string): string {
-  return property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
+  const flag = property
+    .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
+    .replace(/_/g, '-')
+    // A leading uppercase letter or underscore would otherwise produce `---flag`, which
+    // commander rejects while the generated command is being built.
+    .replace(/^-+/, '');
+  // Commander reads `--no-x` as a negated boolean: it stores the parsed value under `x` and
+  // defaults it to true when the flag is absent, so the generated command would never see it.
+  return flag.startsWith('no-') ? `no${flag.slice(3)}` : flag;
 }
 
 export const toolsTestHelpers = {

--- a/src/cli/list-signature.ts
+++ b/src/cli/list-signature.ts
@@ -155,11 +155,17 @@ function inferReturnTypeName(schema: unknown): string | undefined {
 
 const TYPE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
-// A reserved word is never a type reference: most of them fail to parse in a type position
-// (`Promise<class>`), and the few TypeScript reads as keyword types (`Promise<void>`) no longer
-// describe what the title said. Both spellings have to be folded like any other non-identifier.
-const RESERVED_WORDS = new Set([
+// A keyword is never a type reference: most of them fail to parse in a type position
+// (`Promise<class>`, `Promise<keyof>`), and the ones TypeScript reads as keyword types
+// (`Promise<void>`, `Promise<string>`) no longer describe what the title said. Both spellings
+// have to be folded like any other non-identifier. The set is measured against the parser rather
+// than assumed: `tests/emit-ts.test.ts` renders a title for every TypeScript keyword and asserts
+// the emitted module still parses.
+const RESERVED_TYPE_NAMES = new Set([
+  'any',
   'await',
+  'bigint',
+  'boolean',
   'break',
   'case',
   'catch',
@@ -181,17 +187,28 @@ const RESERVED_WORDS = new Set([
   'if',
   'import',
   'in',
+  'infer',
   'instanceof',
+  'keyof',
+  'never',
   'new',
   'null',
+  'number',
+  'object',
+  'readonly',
   'return',
+  'string',
   'super',
   'switch',
+  'symbol',
   'this',
   'throw',
   'true',
   'try',
   'typeof',
+  'undefined',
+  'unique',
+  'unknown',
   'var',
   'void',
   'while',
@@ -202,7 +219,7 @@ const RESERVED_WORDS = new Set([
 // A schema title is prose, but this value is emitted as a TypeScript type name by `emit-ts`,
 // so anything that is not already an identifier has to be folded into one.
 function toTypeName(title: string): string | undefined {
-  if (TYPE_NAME_PATTERN.test(title) && !RESERVED_WORDS.has(title)) {
+  if (TYPE_NAME_PATTERN.test(title) && !RESERVED_TYPE_NAMES.has(title)) {
     return title;
   }
   const joined = title

--- a/src/cli/list-signature.ts
+++ b/src/cli/list-signature.ts
@@ -155,10 +155,54 @@ function inferReturnTypeName(schema: unknown): string | undefined {
 
 const TYPE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
+// A reserved word is never a type reference: most of them fail to parse in a type position
+// (`Promise<class>`), and the few TypeScript reads as keyword types (`Promise<void>`) no longer
+// describe what the title said. Both spellings have to be folded like any other non-identifier.
+const RESERVED_WORDS = new Set([
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'null',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
+
 // A schema title is prose, but this value is emitted as a TypeScript type name by `emit-ts`,
 // so anything that is not already an identifier has to be folded into one.
 function toTypeName(title: string): string | undefined {
-  if (TYPE_NAME_PATTERN.test(title)) {
+  if (TYPE_NAME_PATTERN.test(title) && !RESERVED_WORDS.has(title)) {
     return title;
   }
   const joined = title

--- a/src/cli/list-signature.ts
+++ b/src/cli/list-signature.ts
@@ -153,8 +153,24 @@ function inferReturnTypeName(schema: unknown): string | undefined {
   return inferSchemaDisplayType(schema as Record<string, unknown>);
 }
 
+const TYPE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// A schema title is prose, but this value is emitted as a TypeScript type name by `emit-ts`,
+// so anything that is not already an identifier has to be folded into one.
+function toTypeName(title: string): string | undefined {
+  if (TYPE_NAME_PATTERN.test(title)) {
+    return title;
+  }
+  const joined = title
+    .split(/[^A-Za-z0-9_$]+/)
+    .filter(Boolean)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join('');
+  return TYPE_NAME_PATTERN.test(joined) ? joined : undefined;
+}
+
 function inferSchemaDisplayType(descriptor: Record<string, unknown>): string {
-  const title = typeof descriptor.title === 'string' ? descriptor.title.trim() : undefined;
+  const title = typeof descriptor.title === 'string' ? toTypeName(descriptor.title.trim()) : undefined;
   if (title) {
     return title;
   }

--- a/tests/emit-ts.test.ts
+++ b/tests/emit-ts.test.ts
@@ -10,6 +10,92 @@ import type { Runtime } from '../src/runtime.js';
 import type { ServerToolInfo } from '../src/runtime.js';
 import { integrationDefinition, listCommentsTool } from './fixtures/tool-fixtures.js';
 
+// Every reserved word, contextual keyword and intrinsic type name TypeScript spells; a schema is
+// free to carry any of them as an `outputSchema.title`.
+const TYPESCRIPT_KEYWORDS = [
+  'abstract',
+  'accessor',
+  'any',
+  'as',
+  'asserts',
+  'async',
+  'await',
+  'bigint',
+  'boolean',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'constructor',
+  'continue',
+  'debugger',
+  'declare',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'from',
+  'function',
+  'get',
+  'global',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'infer',
+  'instanceof',
+  'interface',
+  'intrinsic',
+  'is',
+  'keyof',
+  'let',
+  'module',
+  'namespace',
+  'never',
+  'new',
+  'null',
+  'number',
+  'object',
+  'of',
+  'out',
+  'override',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'readonly',
+  'require',
+  'return',
+  'satisfies',
+  'set',
+  'static',
+  'string',
+  'super',
+  'switch',
+  'symbol',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'type',
+  'typeof',
+  'undefined',
+  'unique',
+  'unknown',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+];
+
 const dashedTool: ServerToolInfo = {
   name: 'API-post-page',
   description: 'Create a Notion page',
@@ -42,6 +128,12 @@ function createRuntimeStub(): Runtime {
     },
     close: async () => {},
   } as unknown as Runtime;
+}
+
+function parseDiagnosticsOf(source: string): string[] {
+  const parsed = ts.createSourceFile('emit.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+  const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  return diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'));
 }
 
 describe('emit-ts templates', () => {
@@ -78,20 +170,20 @@ describe('emit-ts templates', () => {
     expect(client).toContain('proxy.aPIPostPage');
 
     for (const source of [types, client]) {
-      const parsed = ts.createSourceFile('emit.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
-      const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
-      expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+      expect(parseDiagnosticsOf(source)).toEqual([]);
     }
   });
 
-  it('keeps a multi-word outputSchema title parseable in the emitted module', () => {
+  // Four cases render the same module for a different title, so the rendering lives here and each
+  // case is left with the title it is about.
+  function renderTypesForTitle(title: string): string {
     const titledTool: ServerToolInfo = {
       ...dashedTool,
       name: 'search',
-      outputSchema: { title: 'Search Results' },
+      outputSchema: { title },
     };
     const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(titledTool)], true);
-    const types = renderTypesModule({
+    return renderTypesModule({
       interfaceName: 'IntegrationTools',
       docs,
       metadata: {
@@ -100,34 +192,36 @@ describe('emit-ts templates', () => {
         generatedAt: new Date('2025-11-07T00:00:00Z'),
       },
     });
+  }
 
-    const parsed = ts.createSourceFile('emit.ts', types, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
-    const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
-    expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+  it('keeps a multi-word outputSchema title parseable in the emitted module', () => {
+    const types = renderTypesForTitle('Search Results');
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
     expect(types).toContain('Promise<SearchResults>');
   });
 
   it('keeps a reserved-word outputSchema title parseable in the emitted module', () => {
-    const titledTool: ServerToolInfo = {
-      ...dashedTool,
-      name: 'search',
-      outputSchema: { title: 'class' },
-    };
-    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(titledTool)], true);
-    const types = renderTypesModule({
-      interfaceName: 'IntegrationTools',
-      docs,
-      metadata: {
-        server: integrationDefinition,
-        generatorLabel: 'mcporter@test',
-        generatedAt: new Date('2025-11-07T00:00:00Z'),
-      },
-    });
+    const types = renderTypesForTitle('class');
 
-    const parsed = ts.createSourceFile('emit.ts', types, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
-    const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
-    expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+    expect(parseDiagnosticsOf(types)).toEqual([]);
     expect(types).toContain('Promise<Class>');
+  });
+
+  it('keeps a type-context keyword outputSchema title parseable in the emitted module', () => {
+    const types = renderTypesForTitle('keyof');
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
+    expect(types).toContain('Promise<Keyof>');
+  });
+
+  // Which spellings TypeScript refuses in a type position is the parser's answer rather than ours,
+  // so every keyword is rendered and handed back to the parser instead of compared against a copy
+  // of the set the source keeps.
+  it.each(TYPESCRIPT_KEYWORDS)('keeps the outputSchema title %s parseable in the emitted module', (keyword) => {
+    const types = renderTypesForTitle(keyword);
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
   });
 
   it('renders client module that wraps proxy calls', () => {

--- a/tests/emit-ts.test.ts
+++ b/tests/emit-ts.test.ts
@@ -84,6 +84,29 @@ describe('emit-ts templates', () => {
     }
   });
 
+  it('keeps a multi-word outputSchema title parseable in the emitted module', () => {
+    const titledTool: ServerToolInfo = {
+      ...dashedTool,
+      name: 'search',
+      outputSchema: { title: 'Search Results' },
+    };
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(titledTool)], true);
+    const types = renderTypesModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata: {
+        server: integrationDefinition,
+        generatorLabel: 'mcporter@test',
+        generatedAt: new Date('2025-11-07T00:00:00Z'),
+      },
+    });
+
+    const parsed = ts.createSourceFile('emit.ts', types, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+    const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+    expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+    expect(types).toContain('Promise<SearchResults>');
+  });
+
   it('renders client module that wraps proxy calls', () => {
     const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(listCommentsTool)], true);
     const metadata = {

--- a/tests/emit-ts.test.ts
+++ b/tests/emit-ts.test.ts
@@ -107,6 +107,29 @@ describe('emit-ts templates', () => {
     expect(types).toContain('Promise<SearchResults>');
   });
 
+  it('keeps a reserved-word outputSchema title parseable in the emitted module', () => {
+    const titledTool: ServerToolInfo = {
+      ...dashedTool,
+      name: 'search',
+      outputSchema: { title: 'class' },
+    };
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(titledTool)], true);
+    const types = renderTypesModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata: {
+        server: integrationDefinition,
+        generatorLabel: 'mcporter@test',
+        generatedAt: new Date('2025-11-07T00:00:00Z'),
+      },
+    });
+
+    const parsed = ts.createSourceFile('emit.ts', types, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+    const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+    expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+    expect(types).toContain('Promise<Class>');
+  });
+
   it('renders client module that wraps proxy calls', () => {
     const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(listCommentsTool)], true);
     const metadata = {

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -396,6 +396,23 @@ describe('flag names stay valid commander flags', () => {
     expect(names).toEqual(['option', 'option-2', 'option-3']);
   });
 
+  it('collapses a run of separators into a single dash', () => {
+    expect(toCliOption('foo__bar')).toBe('foo-bar');
+    expect(toCliOption('foo-_bar')).toBe('foo-bar');
+    expect(toCliOption('a__b__c')).toBe('a-b-c');
+    // An underscore in front of a capital spells the same run, and it is the shape a schema
+    // reaches by mixing the two conventions rather than by repeating one.
+    expect(toCliOption('filter_Query')).toBe('filter-query');
+    expect(buildPlaceholder('foo__bar', 'string')).toBe('<foo-bar>');
+  });
+
+  it('drops a trailing separator', () => {
+    expect(toCliOption('foo_')).toBe('foo');
+    expect(toCliOption('foo__')).toBe('foo');
+    // Every character still normalizing away keeps the stem rather than collapsing to nothing.
+    expect(toCliOption('_-_')).toBe('option');
+  });
+
   it('keeps unaffected property names unchanged', () => {
     expect(toCliOption('inputValue')).toBe('input-value');
     expect(toCliOption('extra_path')).toBe('extra-path');
@@ -483,6 +500,38 @@ describe('generated commands agree with commander', () => {
     }
     expect(block).toContain('args.___ = cmdOpts.option;');
     expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
+  it('registers a flag for a property that repeats or trails a separator', () => {
+    const block = renderBlock(
+      { foo__bar: { type: 'string' }, baz_: { type: 'string' }, filter_Query: { type: 'string' } },
+      ['foo__bar']
+    );
+    const flags = emittedFlags(block);
+    expect(flags).toEqual(['--foo-bar <foo-bar>', '--baz <baz>', '--filter-query <filter-query>']);
+    // commander derives the storage key while addOption registers the flag, so an empty
+    // segment left by a dash run only surfaces here - constructing the Option alone passes.
+    const command = new Command('fetch');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    expect(block).toContain('args.foo__bar = cmdOpts.fooBar;');
+    expect(block).toContain('args.baz_ = cmdOpts.baz;');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
+  it('keeps distinct flags for two spellings that collapse onto one', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { foo__bar: { type: 'string' }, foo_bar: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['foo-bar', 'foo-bar-2']);
   });
 
   it('emits a parseable command for a flag commander stores under a non-identifier key', () => {

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -1,4 +1,4 @@
-import { Option } from 'commander';
+import { Command, Option } from 'commander';
 import { describe, expect, it } from 'vitest';
 import {
   buildExampleValue,
@@ -365,6 +365,18 @@ describe('flag names stay valid commander flags', () => {
     expect(buildPlaceholder('no_cache', 'boolean')).toBe('<no-cache:true|false>');
   });
 
+  it('skips a suffix another property already spells', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { Query: { type: 'string' }, query: { type: 'string' }, query_2: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['query', 'query-3', 'query-2']);
+  });
+
   it('keeps unaffected property names unchanged', () => {
     expect(toCliOption('inputValue')).toBe('input-value');
     expect(toCliOption('extra_path')).toBe('extra-path');
@@ -399,6 +411,37 @@ describe('generated commands agree with commander', () => {
     for (const flag of flags) {
       expect(() => new Option(flag, 'Set the option.')).not.toThrow();
     }
+  });
+
+  it('gives every property its own flag when two spellings normalize onto one', () => {
+    const block = renderBlock(
+      {
+        Query: { type: 'string' },
+        query: { type: 'string' },
+        no_cache: { type: 'boolean' },
+        noCache: { type: 'boolean' },
+      },
+      ['Query']
+    );
+    const flags = emittedFlags(block);
+    expect(flags).toEqual([
+      '--query <query>',
+      '--query-2 <query-2>',
+      '--no-cache <no-cache:true|false>',
+      '--no-cache-2 <no-cache-2:true|false>',
+    ]);
+    // commander refuses a command that declares one flag twice, so the emitted set has to be
+    // free of duplicates before the generated module can even be loaded.
+    const command = new Command('search');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    const properties = ['Query', 'query', 'no_cache', 'noCache'];
+    properties.forEach((property, index) => {
+      expect(block).toContain(`args.${property} = cmdOpts.${storedKey(flags[index] as string)}`);
+    });
   });
 
   it('reads every option from the key commander stores it under', () => {

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -1,3 +1,4 @@
+import { Option } from 'commander';
 import { describe, expect, it } from 'vitest';
 import {
   buildExampleValue,
@@ -16,6 +17,7 @@ import {
   toCliOption,
   toProxyMethodName,
 } from '../src/cli/generate/tools.js';
+import { renderToolCommand } from '../src/cli/generate/template.js';
 import type { ServerToolInfo } from '../src/runtime.js';
 
 describe('generate helpers', () => {
@@ -346,5 +348,57 @@ describe('generate helpers', () => {
         placeholder: '<fields>',
       })
     ).toBe('{"key":"value"}');
+  });
+});
+
+describe('flag names stay valid commander flags', () => {
+  it('does not leak a leading dash from an uppercase property name', () => {
+    expect(toCliOption('Query')).toBe('query');
+    expect(toCliOption('QueryText')).toBe('query-text');
+    expect(buildPlaceholder('Query', 'string')).toBe('<query>');
+    expect(buildPlaceholder('Query', 'array', ['web', 'news'])).toBe('<query:web|news,...>');
+  });
+
+  it('avoids the --no- prefix commander reserves for negation', () => {
+    expect(toCliOption('no_cache').startsWith('no-')).toBe(false);
+    expect(toCliOption('noCache')).toBe(toCliOption('no_cache'));
+    expect(buildPlaceholder('no_cache', 'boolean')).toBe(`<${toCliOption('no_cache')}:true|false>`);
+  });
+
+  it('keeps unaffected property names unchanged', () => {
+    expect(toCliOption('inputValue')).toBe('input-value');
+    expect(toCliOption('extra_path')).toBe('extra-path');
+    expect(toCliOption('nodes')).toBe('nodes');
+  });
+});
+
+function renderBlock(properties: Record<string, unknown>, required: string[]): string {
+  return renderToolCommand(
+    buildToolMetadata({ name: 'fetch', inputSchema: { type: 'object', properties, required } } as ServerToolInfo),
+    30_000,
+    'demo'
+  ).block;
+}
+
+function emittedFlags(block: string): string[] {
+  return [...block.matchAll(/\.option\("([^"]+)"/g)].flatMap((match) => (match[1] ? [match[1]] : []));
+}
+
+describe('generated commands agree with commander', () => {
+  it('emits option flags commander accepts', () => {
+    const flags = emittedFlags(renderBlock({ Query: { type: 'string' } }, ['Query']));
+    expect(flags).toHaveLength(1);
+    for (const flag of flags) {
+      expect(() => new Option(flag, 'Set the option.')).not.toThrow();
+    }
+  });
+
+  it('reads every option from the key commander stores it under', () => {
+    const block = renderBlock({ no_cache: { type: 'boolean' }, url: { type: 'string' } }, ['no_cache', 'url']);
+    const flags = emittedFlags(block);
+    expect(flags).toHaveLength(2);
+    for (const flag of flags) {
+      expect(block).toContain(`cmdOpts.${new Option(flag, 'Set the option.').attributeName()}`);
+    }
   });
 });

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -485,6 +485,13 @@ describe('generated commands agree with commander', () => {
     expect(parseDiagnosticsOf(block)).toEqual([]);
   });
 
+  it('emits a parseable command for a flag commander stores under a non-identifier key', () => {
+    const block = renderBlock({ '2fa': { type: 'string' } }, ['2fa']);
+    expect(emittedFlags(block)).toEqual(['--2fa <2fa>']);
+    expect(block).toContain('args["2fa"] = cmdOpts["2fa"];');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
   it('reads every option from the key commander stores it under', () => {
     const block = renderBlock(
       { no_cache: { type: 'boolean' }, nocache: { type: 'boolean' }, url: { type: 'string' } },

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -359,10 +359,10 @@ describe('flag names stay valid commander flags', () => {
     expect(buildPlaceholder('Query', 'array', ['web', 'news'])).toBe('<query:web|news,...>');
   });
 
-  it('avoids the --no- prefix commander reserves for negation', () => {
-    expect(toCliOption('no_cache').startsWith('no-')).toBe(false);
-    expect(toCliOption('noCache')).toBe(toCliOption('no_cache'));
-    expect(buildPlaceholder('no_cache', 'boolean')).toBe(`<${toCliOption('no_cache')}:true|false>`);
+  it('keeps distinct flags for property names that only differ by the no- prefix', () => {
+    expect(toCliOption('no_cache')).toBe('no-cache');
+    expect(toCliOption('nocache')).toBe('nocache');
+    expect(buildPlaceholder('no_cache', 'boolean')).toBe('<no-cache:true|false>');
   });
 
   it('keeps unaffected property names unchanged', () => {
@@ -380,8 +380,16 @@ function renderBlock(properties: Record<string, unknown>, required: string[]): s
   ).block;
 }
 
+// Mirrors defineOption in the generated module: mcporter derives flag names from schema
+// property names, so commander is told not to read a leading no- as a negation.
+function storedKey(flags: string): string {
+  const option = new Option(flags, 'Set the option.');
+  option.negate = false;
+  return option.attributeName();
+}
+
 function emittedFlags(block: string): string[] {
-  return [...block.matchAll(/\.option\("([^"]+)"/g)].flatMap((match) => (match[1] ? [match[1]] : []));
+  return [...block.matchAll(/\.addOption\(defineOption\("([^"]+)"/g)].flatMap((match) => (match[1] ? [match[1]] : []));
 }
 
 describe('generated commands agree with commander', () => {
@@ -394,11 +402,15 @@ describe('generated commands agree with commander', () => {
   });
 
   it('reads every option from the key commander stores it under', () => {
-    const block = renderBlock({ no_cache: { type: 'boolean' }, url: { type: 'string' } }, ['no_cache', 'url']);
+    const block = renderBlock(
+      { no_cache: { type: 'boolean' }, nocache: { type: 'boolean' }, url: { type: 'string' } },
+      ['no_cache', 'url']
+    );
     const flags = emittedFlags(block);
-    expect(flags).toHaveLength(2);
+    expect(flags).toHaveLength(3);
+    expect(new Set(flags).size).toBe(3);
     for (const flag of flags) {
-      expect(block).toContain(`cmdOpts.${new Option(flag, 'Set the option.').attributeName()}`);
+      expect(block).toContain(`cmdOpts.${storedKey(flag)}`);
     }
   });
 });

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -402,3 +402,34 @@ describe('generated commands agree with commander', () => {
     }
   });
 });
+
+function buildSourcesOption(type: unknown): unknown {
+  return extractOptions({
+    name: 'search',
+    inputSchema: {
+      type: 'object',
+      properties: { sources: { type, items: { type: 'string', enum: ['web', 'news'] } } },
+      required: [],
+    },
+  } as ServerToolInfo)[0];
+}
+
+describe('nullable array schemas keep their array shape', () => {
+  const nullableEnumArray = {
+    type: ['array', 'null'],
+    items: { type: 'string', enum: ['web', 'news'] },
+  };
+
+  it('resolves item types through a nullable array container', () => {
+    expect(inferArrayItemType(nullableEnumArray)).toBe('string');
+    expect(inferArrayItemType({ type: ['array', 'null'], items: { type: 'number' } })).toBe('number');
+  });
+
+  it('resolves enum members through a nullable array container', () => {
+    expect(getEnumValues(nullableEnumArray)).toEqual(['web', 'news']);
+  });
+
+  it('renders the same option for a nullable array as for a plain array', () => {
+    expect(buildSourcesOption(['array', 'null'])).toEqual(buildSourcesOption('array'));
+  });
+});

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from 'commander';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import {
   buildExampleValue,
@@ -377,6 +378,24 @@ describe('flag names stay valid commander flags', () => {
     expect(names).toEqual(['query', 'query-3', 'query-2']);
   });
 
+  it('gives a property whose characters all normalize away a usable flag name', () => {
+    expect(toCliOption('___')).toBe('option');
+    expect(toCliOption('_')).toBe('option');
+    expect(buildPlaceholder('___', 'string')).toBe('<option>');
+  });
+
+  it('assigns the fallback stem before suffixing so every name stays a long flag', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { ___: { type: 'string' }, _: { type: 'boolean' }, option: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['option', 'option-2', 'option-3']);
+  });
+
   it('keeps unaffected property names unchanged', () => {
     expect(toCliOption('inputValue')).toBe('input-value');
     expect(toCliOption('extra_path')).toBe('extra-path');
@@ -398,6 +417,14 @@ function storedKey(flags: string): string {
   const option = new Option(flags, 'Set the option.');
   option.negate = false;
   return option.attributeName();
+}
+
+// The generated block is spliced into a TypeScript module, so a flag name that cannot be
+// spelled as a property access has to be read through a subscript for the module to parse.
+function parseDiagnosticsOf(source: string): string[] {
+  const parsed = ts.createSourceFile('command.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+  const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  return diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'));
 }
 
 function emittedFlags(block: string): string[] {
@@ -442,6 +469,20 @@ describe('generated commands agree with commander', () => {
     properties.forEach((property, index) => {
       expect(block).toContain(`args.${property} = cmdOpts.${storedKey(flags[index] as string)}`);
     });
+  });
+
+  it('emits a long flag for a property whose characters all normalize away', () => {
+    const block = renderBlock({ ___: { type: 'string' }, _: { type: 'boolean' } }, ['___']);
+    const flags = emittedFlags(block);
+    expect(flags).toEqual(['--option <option>', '--option-2 <option-2:true|false>']);
+    const command = new Command('fetch');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    expect(block).toContain('args.___ = cmdOpts.option;');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
   });
 
   it('reads every option from the key commander stores it under', () => {

--- a/tests/generate-cli.test.ts
+++ b/tests/generate-cli.test.ts
@@ -655,7 +655,7 @@ describeGenerateCli('generateCli', () => {
       includeTools: ['set_cells_batch'],
     });
     const content = await fs.readFile(renderedPath, 'utf8');
-    expect(content).toContain('.option("--cells <cells:value1,value2>"');
+    expect(content).toContain('defineOption("--cells <cells:value1,value2>"');
     expect(content).not.toContain('.requiredOption("--cells');
 
     const { execFile } = await import('node:child_process');


### PR DESCRIPTION
## Summary

`mcporter generate-cli` derives every flag name from the tool's JSON Schema property name. Two legal property spellings produce a flag that commander does not read the way the generated code expects.

The first one is fatal. A property whose name starts with an uppercase letter produces `---query`, which commander rejects while it is still constructing the option, so the generated artifact throws at module load and no command in it can run, not even `--help`. Uppercase property names are what the .NET and Java MCP server SDKs emit by default.

### Root cause

`toCliOption` prefixes a dash for every uppercase character with no guard for the leading position, and `buildPlaceholder` repeats the same expression instead of calling it:

```ts
// src/cli/generate/tools.ts:425
export function toCliOption(property: string): string {
  return property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
}

// src/cli/generate/tools.ts:168
const normalized = property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
```

`Query` becomes `-query`, so the emitted line is `.option("---query <-query>", ...)`:

```
Error: option creation failed due to '---query' in option flags '---query <-query>'
- unrecognised flag format
    at splitOptionFlags (commander/lib/option.js:368:11)
    at new Option (commander/lib/option.js:20:25)
    at Command.createOption (commander/lib/command.js:587:12)
```

The second spelling fails more quietly. `no_cache` becomes `--no-cache`, which commander treats as a negated boolean:

```
new Option('--no-cache <no-cache:true|false>').attributeName()  ->  'cache'   (negate = true)
```

The generated command reads the key it computed itself, `cmdOpts.noCache` (`src/cli/generate/template.ts:449`), which is therefore always `undefined`. Commander also gives a negated option an implicit `true` default, so the argument is dropped when the option is optional and reported as missing when it is required, even though the user supplied it.

## Fix

Derive the flag and its placeholder from one helper and drop a leading dash, so the name commander is handed is always a valid long flag.

For the `--no-` case the first revision escaped the flag to `--nocache`; review pointed out that this collapses onto a `nocache` property a schema may legally declare alongside `no_cache`, emitting two identical flags. Any escape can collide with some other legal name, so the flag is now spelled straight from the property and the generated module builds each option explicitly instead:

```ts
function defineOption(flags, description, parser) {
  const option = new Option(flags, description);
  if (parser) option.argParser(parser);
  option.negate = false;
  return option;
}
```

`attributeName()` is then `noCache`, which is the key the generated command already computes, and an absent flag stays `undefined` rather than defaulting to `true`.

### Collision: two spellings that normalize onto one flag

Fifth commit. `Query` beside `query`, or `no_cache` beside `noCache`, are distinct legal properties that both normalize to one flag, and commander refuses a command that declares the same flag twice, so `addOption` throws while the command is being built:

```
Error: Cannot add option '--query <query>' to command 'search' due to conflicting flag '--query'
-  already used by option '--query <query>'
```

This one is not new here - a `no_cache`/`noCache` schema already dies that way on `ae3d900` - but `Query` used to crash on `---query` before any collision could matter, so fixing that spelling exposes the pair. Flag names are therefore assigned across the whole property list rather than per property: schema order keeps the plain flag, and a later property takes the first `-2`, `-3`, ... suffix that no other property claims naturally, so a schema that also declares `query_2` does not get a second `--query-2`. The placeholder is built from the assigned name, and the generated command keeps reading `args.<property>` from the key commander stores that flag under.

### Empty flag name: a property whose characters all normalize away

Sixth and seventh commits. `___` is a legal property name whose every character normalizes away, leaving an empty flag name, and the empty name is inherited by the suffix pass as well, so a schema declaring `_` beside it emits `---2`:

```
.addOption(defineOption("-- <>", "Underscore-only property"))
.addOption(defineOption("---2 <2:true|false>", "Single underscore property", ...))

new Option('-- <>')  ->  Error: option creation failed due to '--' in option flags '-- <>'
```

The stem is therefore assigned inside `toCliOption`, before names reach the collision pass, so it participates in flag assignment like any natural name and a schema declaring `option` beside `___` still gets two distinct flags.

The empty name is also spliced into the generated source as a property access, so the artifact fails to transpile before commander is reached - `cmdOpts.` and `args.___ = cmdOpts.;`. That half outlives the stem fix for one more spelling: `2fa` is legal, `--2fa` is a flag commander accepts and stores under the key `2fa`, but `cmdOpts.2fa` does not parse. Seventh commit, droppable on its own - a key that cannot be spelled as a property access is read through a subscript, and every key that can be is emitted unchanged:

```ts
function propertyAccess(target: string, key: string): string {
  return /^[A-Za-z_$][\w$]*$/.test(key) ? `${target}.${key}` : `${target}[${JSON.stringify(key)}]`;
}
```

A fixture declaring all four properties at once:

```
before  $ ./proof-cli.ts --help
        Error [TransformError]: Transform failed with 1 error:
        proof-cli.ts:134:46: ERROR: Expected identifier but found ","

after   $ ./proof-cli.ts --help
        Embedded tools
          verify - Verify a code
            --option <option> [--option-2 <option-2:true|false>] [--option-3 <option-3>]
            --2fa <2fa> [--raw <json>]

        $ ./proof-cli.ts verify --option underscores --option-2 true             --option-3 "named option" --2fa 123456
        {"___":"underscores","_":true,"option":"named option","2fa":"123456"}
```

### Empty flag segment: a separator run or a trailing separator

Eighth commit, from review. Commander derives an option's storage key by splitting the flag on dashes and upper-casing each segment's first character, so a segment that is empty has no character to read:

```
new Option('--foo--bar <v>')                       ->  fine, construction never inspects the name
new Command('t').addOption(new Option('--foo--bar <v>'))
  TypeError: Cannot read properties of undefined (reading 'toUpperCase')
      at Option.attributeName (commander/lib/option.js:221:12)
      at Command.addOption (commander/lib/command.js:675:25)
```

Three property shapes reached such a segment: `foo__bar` (a run), `baz_` (a trailing separator) and `filter_Query`, which reaches a run by mixing the two naming conventions rather than by repeating one - the uppercase rule emits `-q` next to the underscore's own dash. Runs are collapsed and one dash is trimmed from either end before names reach the collision pass, so `foo__bar` beside `foo_bar` still gets two flags. Enumerating every property name up to five characters over `a B _ - 2 .` and registering each emitted flag on a real `Command` rejects none of the 9330.

Unlike the leading-dash case this one is invisible at construction, so it is pinned at `Command.addOption` rather than at `new Option`.

### Adjacent finding: a nullable array loses its item type and its enum members

Second commit, drop it if you would rather not take it - one helper plus two call sites.

`inferType` already normalizes a union `type` such as `["array", "null"]` to `array` (pinned by `tests/generate-cli-helpers.test.ts:137`), but the two container checks beside it compare the raw value:

```ts
// src/cli/generate/tools.ts:347
if (record.type !== 'array' || !record.items || typeof record.items !== 'object') {
  return 'unknown';
}

// src/cli/generate/tools.ts:138
if (record.type === 'array' && typeof record.items === 'object' && record.items !== null) {
```

The option is still generated as an array while its item type and enum members are dropped, so the signature, the placeholder, the help choices and the call example all disagree for one descriptor. For a numeric variant the generated parser then picks `parseArrayOption(value, 'string')`, so `--scores 1,2` reaches the tool as `["1","2"]`.

### Adjacent finding: a multi-word `outputSchema.title` makes the emitted TypeScript unparseable

Third and fourth commits, also droppable - one helper in `list-signature.ts`.

`inferSchemaDisplayType` returns the raw title and `emit-ts` splices that value into the emitted interface as a type name, so `{"title":"Search Results"}` produces `Promise<Search Results>` and the emitted `.d.ts` does not parse. This only changes how a title is folded into an identifier; it does not change the existing decision to use the title as the type name.

Review pointed out that a title spelling a reserved word, such as `class`, already matches the identifier pattern and so was still emitted verbatim as `Promise<class>`. Reserved words now fail that test and fold like any other non-identifier title, so the title survives as `Class` instead of being dropped. The set was measured with `tsc` rather than assumed: 30 reserved words fail to parse in that position, and `void`, `null`, `true`, `false` and `this` parse into a keyword type that no longer describes the schema.

## Behavior proof

One stdio fixture, one tool, exercising all three cases at once:

```json
{"name":"search","description":"Search the web",
 "inputSchema":{"type":"object","required":["Query","no_cache"],"properties":{
   "Query":    {"type":"string","description":"Search text"},
   "no_cache": {"type":"boolean","description":"Bypass the cache"},
   "nocache":  {"type":"boolean","description":"Legacy flag"},
   "sources":  {"type":["array","null"],"items":{"type":"string","enum":["web","news"]}}}},
 "outputSchema":{"title":"Search Results","type":"object"}}
```

Generated CLI:

```
before  $ mcporter generate-cli --command "node proof-server.mjs" --name proof --output ./proof-cli.ts
        Generated CLI at ./proof-cli.ts
        $ ./proof-cli.ts --help
        commander/lib/option.js:368
            throw new Error(`${baseError}
        Error: option creation failed due to '---query' in option flags '---query <-query>'
        - unrecognised flag format

after   $ ./proof-cli.ts --help
        Embedded tools
          search - Search the web
            --query <query> --no-cache <no-cache:true|false> [--nocache <nocache:true|false>]
            [--sources <sources:web|news,...>] [--raw <json>]

        $ ./proof-cli.ts search --query "mcp" --no-cache true --nocache false --sources web,news
        {"Query":"mcp","no_cache":true,"nocache":false,"sources":["web","news"]}
```

The `no_cache` case on its own. The crash above hides it, so this run uses the same fixture with `Query` renamed to `query`:

```
before  $ ./proof-cli.ts search --query mcp --no-cache true --nocache false
        Missing required option: --no-cache

after   $ ./proof-cli.ts search --query mcp --no-cache true --nocache false
        {"query":"mcp","no_cache":true,"nocache":false}
```

`mcporter list proof`:

```
before    function search(Query: string, no_cache: boolean, nocache?: boolean,
                          sources?: unknown[]): Search Results;

after     function search(Query: string, no_cache: boolean, nocache?: boolean,
                          sources?: ("web" | "news")[]): SearchResults;
```

`mcporter emit-ts proof --mode types`:

```
before    search(..., sources?: unknown[]): Promise<Search Results>;
          $ tsc --noEmit --skipLibCheck --ignoreConfig proof-types.d.ts
          proof-types.d.ts(16,100): error TS1005: '>' expected.
          proof-types.d.ts(16,108): error TS1109: Expression expected.
          proof-types.d.ts(17,1):   error TS1128: Declaration or statement expected.

after     search(..., sources?: ("web" | "news")[]): Promise<SearchResults>;
          $ tsc --noEmit --skipLibCheck --ignoreConfig proof-types.d.ts
          (no output)
```

## Tests

The new cases, red against unpatched `main`:

```
tests/generate-cli-helpers.test.ts
  x does not leak a leading dash from an uppercase property name
  x skips a suffix another property already spells
  x emits option flags commander accepts
  x gives every property its own flag when two spellings normalize onto one
  x gives a property whose characters all normalize away a usable flag name
  x assigns the fallback stem before suffixing so every name stays a long flag
  x emits a long flag for a property whose characters all normalize away
  x emits a parseable command for a flag commander stores under a non-identifier key
  x collapses a run of separators into a single dash
  x drops a trailing separator
  x registers a flag for a property that repeats or trails a separator
  x keeps distinct flags for two spellings that collapse onto one
  x reads every option from the key commander stores it under
  x resolves item types through a nullable array container
  x resolves enum members through a nullable array container
  x renders the same option for a nullable array as for a plain array
tests/emit-ts.test.ts
  x keeps a multi-word outputSchema title parseable in the emitted module
  x keeps a reserved-word outputSchema title parseable in the emitted module

Tests  53 failed | 65 passed (118)
```

One more case, `keeps distinct flags for property names that only differ by the no- prefix`, passes on both revisions by design: it is the guard against the escape this PR first tried and then dropped.

Four of the cases build the options through `renderToolCommand` and hand the emitted flag strings to commander's own `Option` and `Command`, so both the flag grammar and the no-duplicates rule are pinned against commander itself rather than against a copy of its rules.

## Gates

Measured on Node 24.18.1, the runtime the repo asks for. `pnpm check` (oxfmt, oxlint `--type-aware --deny-warnings`, `tsc --noEmit`) is clean on this branch.

```
pnpm test    198 files: 2 failed | 190 passed | 6 skipped
             1764 tests: 7 failed | 1663 passed | 94 skipped
```

The seven live in `tests/chrome-devtools-relay-handoff.test.ts` and `tests/runtime-chrome-relay-handoff.test.ts`, and they are a property of this Windows machine rather than of this branch. Reverting the branch's three production files to `ae3d900` and rerunning those two suites gives the same seven test names, character for character:

```
                                          production files @ ae3d900   this branch
tests/chrome-devtools-relay-handoff        7 failed | 2 passed          7 failed | 2 passed
tests/runtime-chrome-relay-handoff         (same 7 names)               (same 7 names)
```

Nothing in this PR touches the relay path. @DominionZA2's Node 24 run of this branch reports 1734 passed with those suites green, which is what the same code looks like off Windows: https://github.com/openclaw/mcporter/pull/332#issuecomment-5425857944

Targeted:

```
pnpm exec vitest run tests/generate-cli-helpers.test.ts tests/emit-ts.test.ts
    118 passed on this branch
    53 failed | 65 passed with the production files reverted to ae3d900

pnpm exec vitest run tests/generate-cli.test.ts
    3 passed | 10 skipped        (the 10 are the suite's own win32 skips)
```

Production delta is +154/-14 across three files; the remaining +381/-4 is tests.
