### PR TITLE
fix(cli): keep dotted tool names in a call selector

### DIFF
--- a/src/cli/call-command.ts
+++ b/src/cli/call-command.ts
@@ -308,9 +308,11 @@ function resolveCallTarget(
   let tool = parsed.tool;
 
   if (selector && !server && selector.includes('.')) {
-    const [left, right] = selector.split('.', 2);
-    server = left;
-    tool = right;
+    // Tool names may contain dots, so only the first one separates the server. Keep the
+    // remainder intact the way the ad-hoc HTTP path and the call-expression parser do.
+    const split = splitServerToolSelector(selector);
+    server = split?.server ?? selector.slice(0, selector.indexOf('.'));
+    tool = split?.tool;
   } else if (selector && !server) {
     server = selector;
   } else if (selector && !tool && selector !== server) {

--- a/src/cli/http-utils.ts
+++ b/src/cli/http-utils.ts
@@ -60,9 +60,11 @@ export function splitHttpToolSelector(input: string): { baseUrl: string; tool: s
     return null;
   }
   const basePath = `${pathname.slice(0, Math.max(0, lastSlash + 1))}${baseSegment}`;
-  // Serialize through URL rather than concatenating the origin, so the query and fragment the
-  // user typed reach the server instead of being dropped from the connection target.
+  // Serialize through URL rather than concatenating the origin, so the query the user typed
+  // reaches the server instead of being dropped from the connection target. The fragment is
+  // never sent on the wire, and keeping it would only stop the configured server from matching.
   url.pathname = basePath.startsWith('/') ? basePath : `/${basePath}`;
+  url.hash = '';
   return { baseUrl: url.href, tool };
 }
 

--- a/src/cli/http-utils.ts
+++ b/src/cli/http-utils.ts
@@ -60,9 +60,10 @@ export function splitHttpToolSelector(input: string): { baseUrl: string; tool: s
     return null;
   }
   const basePath = `${pathname.slice(0, Math.max(0, lastSlash + 1))}${baseSegment}`;
-  const normalizedPath = basePath.startsWith('/') ? basePath : `/${basePath}`;
-  const baseUrl = `${url.origin}${normalizedPath}`;
-  return { baseUrl, tool };
+  // Serialize through URL rather than concatenating the origin, so the query and fragment the
+  // user typed reach the server instead of being dropped from the connection target.
+  url.pathname = basePath.startsWith('/') ? basePath : `/${basePath}`;
+  return { baseUrl: url.href, tool };
 }
 
 export function normalizeHttpUrl(value: string | URL): string | undefined {

--- a/tests/cli-call-execution.test.ts
+++ b/tests/cli-call-execution.test.ts
@@ -41,6 +41,33 @@ describe('CLI call execution behavior', () => {
     logSpy.mockRestore();
   });
 
+  it('keeps every dot after the server name in a tool selector', async () => {
+    const { handleCall } = await cliModulePromise;
+    const { runtime, callTool } = createRuntimeStub({
+      browser: [
+        {
+          name: 'browser.navigate',
+          description: 'Navigate the browser',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              url: { type: 'string' },
+            },
+            required: ['url'],
+          },
+        },
+      ],
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await handleCall(runtime, ['browser.browser.navigate', '--url', 'https://example.com']);
+    expect(callTool).toHaveBeenCalledWith(
+      'browser',
+      'browser.navigate',
+      expect.objectContaining({ args: { url: 'https://example.com' } })
+    );
+    logSpy.mockRestore();
+  });
+
   it('restores numeric-looking key=value args to schema-declared strings', async () => {
     const { handleCall } = await cliModulePromise;
     const { runtime, callTool, listTools } = createRuntimeStub({

--- a/tests/http-utils.test.ts
+++ b/tests/http-utils.test.ts
@@ -10,11 +10,17 @@ describe('normalizeHttpUrl', () => {
 });
 
 describe('splitHttpToolSelector', () => {
-  it('keeps the query and fragment on the server URL', () => {
+  it('keeps the query on the server URL and drops the fragment', () => {
     expect(splitHttpToolSelector('https://example.com/a/mcp.tool?tenant=b#frag')).toEqual({
-      baseUrl: 'https://example.com/a/mcp?tenant=b#frag',
+      baseUrl: 'https://example.com/a/mcp?tenant=b',
       tool: 'tool',
     });
+  });
+
+  it('lets a configured server without a fragment still match a fragment selector', () => {
+    const selector = splitHttpToolSelector('https://example.com/mcp.tool#frag');
+    expect(selector).not.toBeNull();
+    expect(normalizeHttpUrl(selector!.baseUrl)).toBe(normalizeHttpUrl('https://example.com/mcp'));
   });
 
   it('keeps the port and the encoded path segments', () => {

--- a/tests/http-utils.test.ts
+++ b/tests/http-utils.test.ts
@@ -1,10 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeHttpUrl } from '../src/cli/http-utils.js';
+import { normalizeHttpUrl, splitHttpToolSelector } from '../src/cli/http-utils.js';
 
 describe('normalizeHttpUrl', () => {
   it('uses URL serialization for origin and path forms', () => {
     expect(normalizeHttpUrl('HTTPS://WWW.Example.COM')).toBe('https://example.com/');
     expect(normalizeHttpUrl('https://www.example.com/mcp/')).toBe('https://example.com/mcp/');
     expect(normalizeHttpUrl('https://www.example.com/mcp')).toBe('https://example.com/mcp');
+  });
+});
+
+describe('splitHttpToolSelector', () => {
+  it('keeps the query and fragment on the server URL', () => {
+    expect(splitHttpToolSelector('https://example.com/a/mcp.tool?tenant=b#frag')).toEqual({
+      baseUrl: 'https://example.com/a/mcp?tenant=b#frag',
+      tool: 'tool',
+    });
+  });
+
+  it('keeps the port and the encoded path segments', () => {
+    expect(splitHttpToolSelector('https://example.com:8443/a%20b/mcp.tool')).toEqual({
+      baseUrl: 'https://example.com:8443/a%20b/mcp',
+      tool: 'tool',
+    });
+  });
+
+  it('lets a configured server with a query still match the selector', () => {
+    const selector = splitHttpToolSelector('https://example.com/mcp.tool?tenant=b');
+    expect(selector).not.toBeNull();
+    expect(normalizeHttpUrl(selector!.baseUrl)).toBe(normalizeHttpUrl('https://example.com/mcp?tenant=b'));
+  });
+
+  it('still rejects a path segment without a tool suffix', () => {
+    expect(splitHttpToolSelector('https://example.com/mcp')).toBeNull();
+    expect(splitHttpToolSelector('https://example.com/.tool')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

`mcporter call <server>.<tool>` truncates the tool name at the second dot, so a tool whose name contains a dot is never reachable through the configured-server path. Tool names like `browser.navigate` are common.

### Root cause

`resolveCallTarget` splits the selector with a limit of two:

```ts
// src/cli/call-command.ts:311
if (selector && !server && selector.includes('.')) {
  const [left, right] = selector.split('.', 2);
  server = left;
  tool = right;
}
```

`'proof.browser.navigate'.split('.', 2)` is `['proof', 'browser']`, so the trailing segment is dropped.

The module already resolves the same string correctly three other ways, and the correct helper sits nineteen lines below the defect in the same file:

```ts
// src/cli/call-command.ts:330 - used only by the ad-hoc HTTP branch at :138
function splitServerToolSelector(selector: string): { server: string; tool: string } | undefined {
  const dotIndex = selector.indexOf('.');
  if (dotIndex <= 0 || dotIndex === selector.length - 1) {
    return undefined;
  }
  return { server: selector.slice(0, dotIndex), tool: selector.slice(dotIndex + 1) };
}
```

`src/cli/call-expression-parser.ts:95` rejoins the remainder, and `src/cli/list-command.ts:552` matches the longest configured server name first, so `mcporter list` resolves the selector that `mcporter call` cannot.

## Fix

Route the configured-server branch through the existing helper. A selector that starts or ends with a dot still produces the same `Missing server name.` / `Missing tool name.` errors as before, since the helper returns `undefined` for both and the fallback keeps the current split point.

### Adjacent finding: the HTTP tool selector drops the query

Second and third commits, drop them if you would rather not take them - four lines in `http-utils.ts` plus four test cases.

`splitHttpToolSelector` rebuilds the server URL by concatenating `url.origin` with a hand-built path, so everything after the path is discarded:

```ts
// src/cli/http-utils.ts:63
const basePath = `${pathname.slice(0, Math.max(0, lastSlash + 1))}${baseSegment}`;
const normalizedPath = basePath.startsWith('/') ? basePath : `/${basePath}`;
const baseUrl = `${url.origin}${normalizedPath}`;
```

`normalizeHttpUrl`, eight lines below in the same module, round-trips through `URL` and keeps the query - that was the change in #325. This function was not part of it, so the two now answer differently for one input:

```
splitHttpToolSelector('https://example.com/a/mcp?tenant=b')   ->  baseUrl 'https://example.com/a/mcp'
normalizeHttpUrl('https://example.com/a/mcp?tenant=b')        ->  'https://example.com/a/mcp?tenant=b'
```

The consequence is not cosmetic: the connection is opened against a different endpoint than the user typed, and because `findServerByHttpUrl` compares through `normalizeHttpUrl`, a configured server whose URL carries a query no longer matches the stripped target, so the CLI silently falls through to an ad-hoc server.

## Behavior proof

**Dotted tool name.** A stdio fixture advertising one tool literally named `browser.navigate`:

```
before  $ mcporter call proof.browser.navigate --url "https://example.com"
        [mcporter] Unable to validate flag '--url' because proof.browser did not provide
        usable tool metadata with an input schema.

after   $ mcporter call proof.browser.navigate --url "https://example.com"
        called browser.navigate with {"url":"https://example.com"}
```

**HTTP selector query.** A local HTTP server that logs the request line and answers 404, so the only thing being measured is where the request went. Same port, same command, both revisions:

```
$ mcporter call "http://127.0.0.1:8932/mcp.navigate?tenant=b" url=x --allow-http

before (main @ ae3d900)     after (this branch)
[server] POST /mcp          [server] POST /mcp?tenant=b
[server] POST /mcp          [server] POST /mcp?tenant=b
[server] GET  /mcp          [server] GET  /mcp?tenant=b
```

## Tests

Three new cases, all red against unpatched `main`:

```
tests/cli-call-execution.test.ts
  x keeps every dot after the server name in a tool selector
tests/http-utils.test.ts
  x keeps the query on the server URL and drops the fragment
  x lets a configured server with a query still match the selector

Tests  3 failed | 24 passed (27)
```

Two further cases pass on both revisions and are there to pin behaviour rather than change it: `keeps the port and the encoded path segments`, and `lets a configured server without a fragment still match a fragment selector`.

The fragment half of the third commit came out of review: keeping `url.hash` would have been a new way to miss a configured server, since `findServerByHttpUrl` normalizes both sides and a fragment is never sent on the wire. Measured before changing it:

```
splitHttpToolSelector('https://example.com/mcp.tool#frag').baseUrl
  -> 'https://example.com/mcp#frag'
normalizeHttpUrl(that)                       -> 'https://example.com/mcp#frag'
normalizeHttpUrl('https://example.com/mcp')  -> 'https://example.com/mcp'
match -> false
```

## Gates

Local runtime is Node 22.20.0 while the repo asks for `>=24`, so three suites fail before this branch as well: `tests/chrome-devtools-relay-handoff.test.ts`, `tests/runtime-chrome-relay-handoff.test.ts` and `tests/oauth-refresh-process.integration.test.ts`.

Running those three on their own and diffing the failing test names between `main` and this branch leaves a single difference, `redeems a rotating refresh token exactly once across concurrent processes (provider path)`, which is flaky here: it failed on `main` in an earlier run of the same three files and passed on `main` in the run used for the diff. Every other failing name is identical on both revisions.

```
pnpm test                     3 files fail on both revisions (8-9 tests, varies by run)
pnpm lint:oxlint              clean
pnpm typecheck                clean for the changed files
                              (tests/oauth-session.test.ts reports 2 errors on main too)
oxfmt --check <changed>       clean
pnpm exec vitest run tests/http-utils.test.ts tests/cli-call-execution.test.ts
                              27 passed
```

Also ran the nine call-related suites plus every consumer of `splitHttpToolSelector` / `extractHttpServerTarget` (`command-inference`, `generate/definition`, `generate/flags`, `emit-ts-command`, `list-command`): 104 and 45 passed respectively.

Production delta is +10/-6 across two files.
