### PR TITLE
fix(oauth): normalize imported token expiry

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -257,6 +257,12 @@ For keep-alive stdio servers, refresh happens before process start. If that proc
 - Keep `config/mcporter.json` under version control. Encourage contributors to add sensitive data via env vars (`${LINEAR_API_KEY}`) rather than inline secrets.
 - For pre-registered OAuth apps, store the public `oauthClientId` in config and point `oauthClientSecretEnv` at a local environment variable. `oauthClientSecret` is supported for private machine-local configs but should not be committed.
 - For headless deployments that already have OAuth credentials, run `mcporter vault set <server> --tokens-file <path>` or `mcporter vault set <server> --stdin` with a JSON payload shaped like `{ "tokens": { ... }, "clientInfo": { ... } }`. This lets mcporter compute the vault key from the resolved server definition instead of duplicating that internal format in scripts.
+- `vault set` normalizes token expiry the same way a live OAuth exchange does, and the payload decides which reading applies:
+  - `expires_at` (or `expiresAt`), a Unix timestamp in seconds, is stored verbatim. Supply it whenever the credentials were issued before this import — a token response saved to disk an hour ago, replayed from a secret manager, or copied between machines.
+  - `expires_in` alone is interpreted as **lifetime remaining at import time**, because the payload carries no issuance timestamp. Importing a stale response under this reading marks an already-dead token as live, and `refreshable_bearer` will hand it to the server rather than refreshing first.
+
+  Scripts that seed credentials straight out of a token endpoint can keep sending `expires_in`. Anything that stores a token response and replays it later should convert once at capture time — `expires_at = <issued_at> + expires_in` — and send that instead.
+
 - Machine-specific additions can live in `~/.mcporter/local.json` or `$XDG_CONFIG_HOME/mcporter/local.json`; point `mcporter config --config ~/.mcporter/local.json add ...` there when you prefer not to touch the repo. Since the runtime only watches one config at a time, CI jobs should always pass `--config config/mcporter.json` (or run from the repo root) for deterministic behavior.
 - OAuth tokens, cached server metadata, and generated CLIs should remain outside the repo (`~/.mcporter/...` or the matching `XDG_*_HOME/mcporter/...`, plus `dist/`).
 

--- a/src/cli/vault-command.ts
+++ b/src/cli/vault-command.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import type { OAuthClientInformationMixed, OAuthTokens } from '@modelcontextprotocol/client';
 import type { Runtime } from '../runtime.js';
+import { prepareStoredTokens } from '../oauth-persistence-stores.js';
 import { clearVaultEntry, getOAuthVaultPath, saveVaultEntry } from '../oauth-vault.js';
 import { CliUsageError } from './errors.js';
 
@@ -48,7 +49,7 @@ async function handleVaultSet(
   const definition = runtime.getDefinition(server);
   const payload = validateVaultPayload(parseVaultPayload(await readPayload(source, options), source));
   await saveVaultEntry(definition, {
-    tokens: payload.tokens,
+    tokens: prepareStoredTokens(payload.tokens),
     ...(payload.clientInfo ? { clientInfo: payload.clientInfo } : {}),
   });
   console.log(`Saved OAuth credentials for '${definition.name}' to ${getOAuthVaultPath()}`);

--- a/src/oauth-persistence-stores.ts
+++ b/src/oauth-persistence-stores.ts
@@ -46,7 +46,7 @@ function withStoredExpiry(tokens: OAuthTokens): OAuthTokens {
   return tokens;
 }
 
-function prepareStoredTokens(tokens: OAuthTokens): OAuthTokens {
+export function prepareStoredTokens(tokens: OAuthTokens): OAuthTokens {
   return withStoredExpiry(withOAuthTokenGeneration(tokens));
 }
 

--- a/tests/vault-command.test.ts
+++ b/tests/vault-command.test.ts
@@ -137,6 +137,36 @@ describe('vault command', () => {
     });
   });
 
+  // A payload carries no issuance timestamp, so `expires_in` can only be read
+  // as lifetime remaining at import. Credentials imported later than they were
+  // issued must therefore say so with an absolute expiry, and that value has to
+  // survive normalization untouched — otherwise a stale token is stored as live
+  // and refreshable_bearer sends it instead of refreshing.
+  for (const alias of ['expires_at', 'expiresAt'] as const) {
+    it(`keeps an explicit ${alias} from a delayed import`, async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_754_611_200_000);
+      // Issued 55 minutes before this import: 5 minutes of the hour remain.
+      const trueExpiry = 1_754_611_200 + 300;
+
+      await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
+        readStdin: async () =>
+          JSON.stringify({
+            tokens: {
+              access_token: 'delayed-token',
+              token_type: 'Bearer',
+              expires_in: 3600,
+              [alias]: trueExpiry,
+            },
+          }),
+      });
+
+      const entry = await loadVaultEntry(definition);
+      expect(entry?.tokens).toMatchObject({ access_token: 'delayed-token', [alias]: trueExpiry });
+      // The relative reading would have stored now + 3600 and hidden the expiry.
+      expect(entry?.tokens?.expires_at ?? entry?.tokens?.expiresAt).not.toBe(1_754_614_800);
+    });
+  }
+
   it('clears the server vault entry', async () => {
     await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
       readStdin: async () => JSON.stringify({ tokens: { access_token: 'token', token_type: 'Bearer' } }),

--- a/tests/vault-command.test.ts
+++ b/tests/vault-command.test.ts
@@ -113,13 +113,16 @@ describe('vault command', () => {
     });
   });
 
-  it('seeds OAuth credentials from stdin JSON', async () => {
+  it('seeds OAuth credentials from stdin JSON and normalizes relative expiry', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_754_611_200_000);
+
     await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
       readStdin: async () =>
         JSON.stringify({
           tokens: {
             access_token: 'stdin-token',
             token_type: 'Bearer',
+            expires_in: 3600,
           },
         }),
     });
@@ -128,28 +131,6 @@ describe('vault command', () => {
       tokens: {
         access_token: 'stdin-token',
         token_type: 'Bearer',
-      },
-    });
-  });
-
-  it('converts a relative token lifetime to an absolute expiry', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(1_754_611_200_000);
-
-    await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
-      readStdin: async () =>
-        JSON.stringify({
-          tokens: {
-            access_token: 'relative-expiry-token',
-            token_type: 'Bearer',
-            refresh_token: 'refresh-token',
-            expires_in: 3600,
-          },
-        }),
-    });
-
-    await expect(loadVaultEntry(definition)).resolves.toMatchObject({
-      tokens: {
-        access_token: 'relative-expiry-token',
         expires_in: 3600,
         expires_at: 1_754_614_800,
       },

--- a/tests/vault-command.test.ts
+++ b/tests/vault-command.test.ts
@@ -132,6 +132,30 @@ describe('vault command', () => {
     });
   });
 
+  it('converts a relative token lifetime to an absolute expiry', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_754_611_200_000);
+
+    await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
+      readStdin: async () =>
+        JSON.stringify({
+          tokens: {
+            access_token: 'relative-expiry-token',
+            token_type: 'Bearer',
+            refresh_token: 'refresh-token',
+            expires_in: 3600,
+          },
+        }),
+    });
+
+    await expect(loadVaultEntry(definition)).resolves.toMatchObject({
+      tokens: {
+        access_token: 'relative-expiry-token',
+        expires_in: 3600,
+        expires_at: 1_754_614_800,
+      },
+    });
+  });
+
   it('clears the server vault entry', async () => {
     await handleVault(runtimeFor(definition), ['set', 'calendar', '--stdin'], {
       readStdin: async () => JSON.stringify({ tokens: { access_token: 'token', token_type: 'Bearer' } }),

--- a/tests/vault-command.test.ts
+++ b/tests/vault-command.test.ts
@@ -160,10 +160,13 @@ describe('vault command', () => {
           }),
       });
 
-      const entry = await loadVaultEntry(definition);
-      expect(entry?.tokens).toMatchObject({ access_token: 'delayed-token', [alias]: trueExpiry });
+      // Both aliases are persistence-only, so they are not on OAuthTokens.
+      const stored = (await loadVaultEntry(definition))?.tokens as
+        | { access_token?: string; expires_at?: number; expiresAt?: number }
+        | undefined;
+      expect(stored?.access_token).toBe('delayed-token');
       // The relative reading would have stored now + 3600 and hidden the expiry.
-      expect(entry?.tokens?.expires_at ?? entry?.tokens?.expiresAt).not.toBe(1_754_614_800);
+      expect(stored?.expires_at ?? stored?.expiresAt).toBe(trueExpiry);
     });
   }
 


### PR DESCRIPTION
## Summary

- normalize tokens imported by `vault set` through the canonical persistence preparation path
- derive `expires_at` from `expires_in` without changing explicit expiry aliases
- preserve the existing atomic token and client-info vault write
- document the expiry import contract and cover both fresh and delayed imports

Closes #334

## Real behavior proof

One harness, three runs, all driving the **real built CLI** (`node dist/cli.js`, not the test runner) against a loopback fake OAuth provider + MCP server, with isolated `HOME` and XDG roots so the developer vault is never touched. The provider counts every `POST /token` and records every `Authorization` header presented at `/mcp`; it honors both the imported and the rotated access token, so nothing below is an artifact of the fixture rejecting a valid credential. All credentials are non-secret fixtures and are redacted anyway.

Run 1 and 2 differ only by the patch. Run 3 covers the delayed-import case raised in review.

### 1. Before — main `ae3d900`: the fresh token is redeemed on first use

```text

$ mcporter vault set demo --stdin   # payload: expires_in 3600, refresh_token present, no expires_at
Saved OAuth credentials for 'demo' to $TMP/data/mcporter/credentials.json
(exit 0)

$ cat $XDG_DATA_HOME/mcporter/credentials.json   # persisted tokens (secrets redacted)
{
  "access_token": "<redacted>",
  "token_type": "Bearer",
  "refresh_token": "<redacted>",
  "expires_in": 3600,
  "expires_at": "(absent)"
}
-> NO absolute expiry persisted (expires_at absent)

$ mcporter list demo   # first use of the freshly imported token
demo

  /**
   * Return pong.
   */
  function ping();

  Examples:
    mcporter call demo.ping()

  1 tool · 51ms · HTTP http://127.0.0.1:58356/mcp
(exit 0)

provider-side observation:
  POST /token requests during first use : 1
    - grant_type=refresh_token refresh_token=<the freshly imported one>
  Authorization headers seen at /mcp    : Bearer <rotated access token>

RESULT: the fresh token was redeemed immediately (1 refresh request(s) to the provider).
```

### 2. After — this branch `c5f11eb`: the imported token is used as-is

```text

$ mcporter vault set demo --stdin   # payload: expires_in 3600, refresh_token present, no expires_at
Saved OAuth credentials for 'demo' to $TMP/data/mcporter/credentials.json
(exit 0)

$ cat $XDG_DATA_HOME/mcporter/credentials.json   # persisted tokens (secrets redacted)
{
  "access_token": "<redacted>",
  "token_type": "Bearer",
  "refresh_token": "<redacted>",
  "expires_in": 3600,
  "expires_at": 1787629745
}
-> expires_at persisted: 3600s in the future

$ mcporter list demo   # first use of the freshly imported token
demo

  /**
   * Return pong.
   */
  function ping();

  Examples:
    mcporter call demo.ping()

  1 tool · 35ms · HTTP http://127.0.0.1:58339/mcp
(exit 0)

provider-side observation:
  POST /token requests during first use : 0
  Authorization headers seen at /mcp    : Bearer <imported access token>

RESULT: the imported token was used as-is; the provider was never asked to redeem the refresh token.
```

### 3. After — delayed import declaring its real expiry: still refreshes first

```text

$ mcporter vault set demo --stdin   # payload: expires_in 3600 AND expires_at = now + 30s (issued 59.5 min ago)
Saved OAuth credentials for 'demo' to $TMP/data/mcporter/credentials.json
(exit 0)

$ cat $XDG_DATA_HOME/mcporter/credentials.json   # persisted tokens (secrets redacted)
{
  "access_token": "<redacted>",
  "token_type": "Bearer",
  "refresh_token": "<redacted>",
  "expires_in": 3600,
  "expires_at": 1787626175
}
-> expires_at persisted: 30s in the future (the supplied value, kept verbatim; the relative reading would have said ~3600s)

$ mcporter list demo   # first use of the freshly imported token
demo

  /**
   * Return pong.
   */
  function ping();

  Examples:
    mcporter call demo.ping()

  1 tool · 52ms · HTTP http://127.0.0.1:58342/mcp
(exit 0)

provider-side observation:
  POST /token requests during first use : 1
    - grant_type=refresh_token refresh_token=<the freshly imported one>
  Authorization headers seen at /mcp    : Bearer <rotated access token>

RESULT: the near-expiry token was refreshed before use (1 refresh request(s)) — the conservative path still runs when the payload declares a real expiry.
```

### What the transcripts show

| | 1. main `ae3d900`, fresh import | 2. branch `c5f11eb`, fresh import | 3. branch `c5f11eb`, delayed import |
|---|---|---|---|
| payload expiry | `expires_in: 3600` | `expires_in: 3600` | `expires_in: 3600` + `expires_at: now+30` |
| `expires_at` persisted | absent | `now + 3600s` | `now + 30s` (verbatim) |
| `POST /token` on first use | **1** | **0** | **1** |
| bearer presented at `/mcp` | rotated | the imported token | rotated |
| `mcporter list demo` | ok | ok | ok |

Run 1 is the P1 defect observed end to end: a one-hour-valid grant is spent on its very first use, because `shouldRefreshCachedToken` falls back to "`expires_in` + `refresh_token` ⇒ due" when no absolute expiry was persisted (`src/oauth-token-refresh.ts:188`). Note that the command still *succeeds* — that is what makes it worth fixing rather than merely noisy. Nothing surfaces to the user, but with rotating refresh tokens (RFC 9700 §4.14.2) the grant the operator just imported has already been consumed.

Run 2 is the fix: the absolute expiry is persisted, the timestamp comparison wins, and the provider is never contacted.

Run 3 answers the review finding directly. A payload that declares its real remaining lifetime keeps that value verbatim and still takes the conservative refresh path before the token is used — the patch does not blanket-suppress refresh for imported credentials, it suppresses it only where the payload says the token is genuinely live.

## Expiry import contract (addresses the delayed-import finding)

`expires_in` is relative to token *issuance*, but `vault set` imports credentials that may already be held, so the payload carries no issuance timestamp. Normalization can only read a relative expiry as lifetime remaining at import — which over-extends a stale response, and `readExplicitRefreshableBearerToken` (`src/oauth-token-refresh.ts:456`) then returns that token directly instead of refreshing.

The mechanism to express a real expiry already exists and is untouched by this patch: `withStoredExpiry` returns tokens verbatim when `expires_at` or `expiresAt` is present, and `validateOAuthTokens` accepts both aliases. What was missing is that this was neither documented nor guarded, so this branch adds both:

- `docs/config.md` now states the contract — an explicit `expires_at` / `expiresAt` (Unix seconds) is stored verbatim and is how delayed credentials should be imported; `expires_in` alone means lifetime remaining at import. Scripts that replay a stored token response should convert once at capture time.
- `tests/vault-command.test.ts` covers a delayed import through both aliases: a token issued 55 minutes before import keeps its real 5-minutes-remaining expiry and is not rewritten to `now + 3600`. Run 3 above is the same case through the real CLI.

Both unit guards were mutation-checked — deleting the alias short-circuit in `withStoredExpiry` fails them, so they are not vacuous.

This keeps the #334 fix intact for the fresh-import case rather than reverting to the unconditional conservative refresh, which would reintroduce the reported bug.

<details>
<summary><strong>Reproduction harness</strong> (drop in <code>tmp/vault-expiry-proof.mjs</code>, then <code>pnpm build && node tmp/vault-expiry-proof.mjs . after-fix fresh</code> / <code>... delayed</code>)</summary>

```js
/**
 * Real-behavior proof for mcporter#335.
 *
 * Runs the actual built CLI (dist/cli.js) against a local fake OAuth provider +
 * MCP server, and reports whether the provider's /token endpoint is hit on the
 * FIRST use of a freshly imported, still-valid (expires_in: 3600) token.
 *
 * Usage: node vault-expiry-proof.mjs <path-to-repo-checkout> <label>
 */
import { execFile } from 'node:child_process';
import fs from 'node:fs/promises';
import { createServer } from 'node:http';
import os from 'node:os';
import path from 'node:path';
import { Readable } from 'node:stream';
import { promisify } from 'node:util';
import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
import { z } from 'zod';

const execFileAsync = promisify(execFile);
const repo = path.resolve(process.argv[2] ?? process.cwd());
const label = process.argv[3] ?? 'run';
const scenario = process.argv[4] ?? 'fresh';
const CLI = path.join(repo, 'dist', 'cli.js');

const SEEDED_ACCESS = 'seeded-access-token';
const SEEDED_REFRESH = 'seeded-refresh-token';

const tokenEndpointHits = [];
const mcpAuthorizations = [];

function sendJson(response, body, status = 200) {
  const payload = JSON.stringify(body);
  response.writeHead(status, { 'content-type': 'application/json' });
  response.end(payload);
}

async function readBody(request) {
  const chunks = [];
  for await (const chunk of request) chunks.push(chunk);
  return Buffer.concat(chunks).toString('utf8');
}

function toWebRequest(request, origin) {
  const url = new URL(request.url ?? '/', origin);
  const headers = new Headers();
  for (const [key, value] of Object.entries(request.headers)) {
    if (Array.isArray(value)) for (const item of value) headers.append(key, item);
    else if (value !== undefined) headers.set(key, value);
  }
  const hasBody = request.method !== 'GET' && request.method !== 'HEAD';
  return new Request(url, {
    method: request.method,
    headers,
    ...(hasBody ? { body: Readable.toWeb(request), duplex: 'half' } : {}),
  });
}

async function writeWebResponse(response, webResponse) {
  const headers = {};
  webResponse.headers.forEach((value, key) => {
    headers[key] = value;
  });
  response.writeHead(webResponse.status, headers);
  if (!webResponse.body) return response.end();
  for await (const chunk of Readable.fromWeb(webResponse.body)) response.write(chunk);
  response.end();
}

const mcpHandler = createMcpHandler(() => {
  const server = new McpServer({ name: 'proof-fixture', version: '1.0.0' }, { capabilities: { tools: {} } });
  server.registerTool(
    'ping',
    { description: 'Return pong.', inputSchema: z.object({}) },
    async () => ({ content: [{ type: 'text', text: 'pong' }] })
  );
  return server;
});

let origin = '';
const server = createServer((request, response) => {
  const url = new URL(request.url ?? '/', origin || 'http://127.0.0.1');

  if (url.pathname.includes('.well-known/oauth-protected-resource')) {
    return sendJson(response, { resource: `${origin}/mcp`, authorization_servers: [origin] });
  }
  if (url.pathname.includes('.well-known/oauth-authorization-server') || url.pathname.includes('openid-configuration')) {
    return sendJson(response, {
      issuer: origin,
      authorization_endpoint: `${origin}/authorize`,
      token_endpoint: `${origin}/token`,
      registration_endpoint: `${origin}/register`,
      response_types_supported: ['code'],
      grant_types_supported: ['authorization_code', 'refresh_token'],
      token_endpoint_auth_methods_supported: ['none'],
      code_challenge_methods_supported: ['S256'],
    });
  }
  if (url.pathname === '/token' && request.method === 'POST') {
    return void readBody(request).then((raw) => {
      const params = new URLSearchParams(raw);
      tokenEndpointHits.push({
        grant_type: params.get('grant_type'),
        presented_refresh_token: params.get('refresh_token'),
      });
      sendJson(response, {
        access_token: 'rotated-access-token',
        token_type: 'Bearer',
        refresh_token: 'rotated-refresh-token',
        expires_in: 3600,
      });
    });
  }
  if (url.pathname === '/mcp') {
    const authorization = request.headers.authorization ?? '(none)';
    mcpAuthorizations.push(authorization);
    if (authorization !== `Bearer ${SEEDED_ACCESS}` && authorization !== 'Bearer rotated-access-token') {
      response.writeHead(401, {
        'www-authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
      });
      return response.end('unauthorized');
    }
    return void mcpHandler
      .fetch(toWebRequest(request, origin))
      .then((webResponse) => writeWebResponse(response, webResponse))
      .catch(() => {
        if (!response.headersSent) response.writeHead(500);
        response.end();
      });
  }
  response.writeHead(404).end('not found');
});

await new Promise((resolve, reject) => {
  server.once('error', reject);
  server.listen(0, '127.0.0.1', resolve);
});
origin = `http://127.0.0.1:${server.address().port}`;

const root = await fs.mkdtemp(path.join(os.tmpdir(), `mcporter-vault-proof-${label}-`));
const env = {
  ...process.env,
  HOME: path.join(root, 'home'),
  XDG_CONFIG_HOME: path.join(root, 'config'),
  XDG_DATA_HOME: path.join(root, 'data'),
  XDG_STATE_HOME: path.join(root, 'state'),
  XDG_CACHE_HOME: path.join(root, 'cache'),
  NO_COLOR: '1',
};
await fs.mkdir(path.join(root, 'config', 'mcporter'), { recursive: true });
await fs.writeFile(
  path.join(root, 'config', 'mcporter', 'mcporter.json'),
  `${JSON.stringify({ mcpServers: { demo: { baseUrl: `${origin}/mcp`, auth: 'oauth' } } }, null, 2)}\n`
);

// 'fresh'   : a token response imported right after issuance (relative expiry only).
// 'delayed' : the same one-hour response, imported 59.5 minutes after it was
//             issued, declaring its true remaining lifetime via expires_at.
const trueExpiry = Math.floor(Date.now() / 1000) + 30;
const payload = {
  tokens: {
    access_token: SEEDED_ACCESS,
    token_type: 'Bearer',
    refresh_token: SEEDED_REFRESH,
    expires_in: 3600,
    ...(scenario === 'delayed' ? { expires_at: trueExpiry } : {}),
  },
  clientInfo: { client_id: 'proof-client', redirect_uris: [`${origin}/callback`] },
};

async function runCli(args, input) {
  try {
    const child = execFileAsync(process.execPath, [CLI, ...args], { env, timeout: 60_000 });
    if (input !== undefined) {
      child.child.stdin.end(input);
    }
    const { stdout, stderr } = await child;
    return { code: 0, stdout, stderr };
  } catch (error) {
    return { code: error.code ?? 1, stdout: error.stdout ?? '', stderr: error.stderr ?? String(error) };
  }
}

const out = [];
const say = (line = '') => out.push(line);

say(`### ${label} (scenario: ${scenario})`);
say(`repo: ${repo}`);
say(`git HEAD: ${(await execFileAsync('git', ['rev-parse', '--short', 'HEAD'], { cwd: repo })).stdout.trim()}`);
say(`fake provider + MCP server: ${origin}`);
say();

say(
  scenario === 'delayed'
    ? `$ mcporter vault set demo --stdin   # payload: expires_in 3600 AND expires_at = now + 30s (issued 59.5 min ago)`
    : `$ mcporter vault set demo --stdin   # payload: expires_in 3600, refresh_token present, no expires_at`
);
const setResult = await runCli(['vault', 'set', 'demo', '--stdin'], JSON.stringify(payload));
say(setResult.stdout.trim().replace(root, '$TMP'));
if (setResult.stderr.trim()) say(setResult.stderr.trim().replace(root, '$TMP'));
say(`(exit ${setResult.code})`);
say();

const vaultPath = path.join(root, 'data', 'mcporter', 'credentials.json');
const vault = JSON.parse(await fs.readFile(vaultPath, 'utf8'));
const entry = Object.values(vault.entries)[0];
say(`$ cat $XDG_DATA_HOME/mcporter/credentials.json   # persisted tokens (secrets redacted)`);
say(
  JSON.stringify(
    {
      access_token: '<redacted>',
      token_type: entry.tokens.token_type,
      refresh_token: '<redacted>',
      expires_in: entry.tokens.expires_in,
      expires_at: entry.tokens.expires_at ?? '(absent)',
    },
    null,
    2
  )
);
const nowSeconds = Math.floor(Date.now() / 1000);
say(
  entry.tokens.expires_at
    ? `-> expires_at persisted: ${entry.tokens.expires_at - nowSeconds}s in the future` +
      (scenario === 'delayed'
        ? ` (the supplied value, kept verbatim; the relative reading would have said ~3600s)`
        : ``)
    : `-> NO absolute expiry persisted (expires_at absent)`
);
say();

const hitsBefore = tokenEndpointHits.length;
say(`$ mcporter list demo   # first use of the freshly imported token`);
const listResult = await runCli(['list', 'demo']);
say(listResult.stdout.trim().replace(root, '$TMP') || '(no stdout)');
if (listResult.stderr.trim()) say(listResult.stderr.trim().replace(root, '$TMP'));
say(`(exit ${listResult.code})`);
say();

const refreshHits = tokenEndpointHits.slice(hitsBefore);
say(`provider-side observation:`);
say(`  POST /token requests during first use : ${refreshHits.length}`);
for (const hit of refreshHits) {
  say(`    - grant_type=${hit.grant_type} refresh_token=${hit.presented_refresh_token === SEEDED_REFRESH ? '<the freshly imported one>' : '<other>'}`);
}
say(`  Authorization headers seen at /mcp    : ${
  mcpAuthorizations.length === 0
    ? '(none)'
    : [...new Set(mcpAuthorizations)]
        .map((value) =>
          value === `Bearer ${SEEDED_ACCESS}`
            ? 'Bearer <imported access token>'
            : value === 'Bearer rotated-access-token'
              ? 'Bearer <rotated access token>'
              : value
        )
        .join(', ')
}`);
say();
say(
  refreshHits.length === 0
    ? 'RESULT: the imported token was used as-is; the provider was never asked to redeem the refresh token.'
    : scenario === 'delayed'
      ? `RESULT: the near-expiry token was refreshed before use (${refreshHits.length} refresh request(s)) — the conservative path still runs when the payload declares a real expiry.`
      : `RESULT: the fresh token was redeemed immediately (${refreshHits.length} refresh request(s) to the provider).`
);

console.log(out.join('\n'));

await new Promise((resolve) => server.close(resolve));
await mcpHandler.close?.();
await fs.rm(root, { recursive: true, force: true });
process.exit(0);
```

</details>

## Tests

- `pnpm exec vitest run tests/vault-command.test.ts` (8 passed)
- `pnpm exec vitest run tests/vault-command.test.ts tests/vault-cli.integration.test.ts tests/oauth-persistence-stores.test.ts` (22 passed: 8 + 9 + 5)
- `pnpm lint:oxlint` (passed)
- `pnpm exec oxfmt --check docs/config.md tests/vault-command.test.ts src/cli/vault-command.ts src/oauth-persistence-stores.ts` (passed)
- `pnpm test` (1,637 passed, 26 skipped; 1 pre-existing failure in `oauth-refresh-process.integration.test.ts`, untouched by this branch)
- `pnpm check` (fails at `format:check` on `tests/cli-list-stdio-logs.test.ts` and `tests/list-inline-stdio.test.ts` — both pre-existing on `main` and not among the four files this branch changes)
