### PR TITLE
fix(config): preserve daemon settings during server edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### CLI
+
+- Preserve top-level daemon idle timeout settings when adding, removing, or copying config server entries.
+
 ### Maintenance
 
 - Refresh runtime, build, test, and lint dependencies plus GitHub Actions caching while preserving the 48-hour dependency release-age policy.

--- a/docs/config.md
+++ b/docs/config.md
@@ -77,6 +77,8 @@ Rules:
 
 Use `--scope home|project` with `mcporter config add` to pick the write target explicitly. `project` is always the default (creating `config/mcporter.json` if needed); `home` writes to the XDG config path when `XDG_CONFIG_HOME` is set, otherwise `~/.mcporter/mcporter.json`, even when a project config is present. `--persist <path>` still takes precedence when you need a custom file.
 
+`config add`, `config remove`, and `config import --copy` preserve supported unrelated top-level settings, including `daemonIdleTimeoutMs` and `daemon_idle_timeout_ms` as written, along with the `imports` list and unaffected server entries. Adding an existing server name or copying an import with a colliding name replaces the whole server entry rather than patching individual fields; omitted fields from the old entry are not retained.
+
 ### `mcporter config list [filter]`
 
 - Shows **local** entries by default. Pass `--source import` to list imported editor configs, or `--json` for machine output.

--- a/src/cli/config/shared.ts
+++ b/src/cli/config/shared.ts
@@ -19,6 +19,7 @@ export type ConfigLocationSummary = {
 
 export function cloneConfig(config: RawConfig): RawConfig {
   return {
+    ...config,
     mcpServers: config.mcpServers ? { ...config.mcpServers } : {},
     imports: config.imports ? [...config.imports] : undefined,
   };

--- a/tests/config-preservation.test.ts
+++ b/tests/config-preservation.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleConfigCli } from '../src/cli/config-command.js';
+import type { RawConfig } from '../src/config.js';
+import { RawConfigSchema } from '../src/config-schema.js';
+import { createTempConfig } from './fixtures/config-fixture.js';
+
+const siblings: RawConfig['mcpServers'] = {
+  siblingOne: {
+    command: 'inert-sibling',
+    args: ['one', 'two'],
+    env: { LABEL: 'unchanged' },
+    allowedTools: ['first', 'second'],
+  },
+  siblingTwo: {
+    base_url: 'https://sibling.invalid/mcp',
+    headers: { 'X-Fixture': 'unchanged' },
+    description: 'Untouched sibling',
+    protocol_version: 'auto',
+  },
+};
+const originalServers: RawConfig['mcpServers'] = {
+  ...siblings,
+  target: {
+    command: 'inert-old-target',
+    args: ['stale-argument'],
+    env: { OLD: 'stale' },
+    headers: { 'X-Old': 'stale' },
+    description: 'Stale target description',
+  },
+};
+const addedEntry = { baseUrl: 'https://added.invalid/mcp' };
+const copiedServers = {
+  target: { baseUrl: 'https://imported.invalid/mcp' },
+  'import-new': { command: 'inert-import', args: ['new'] },
+};
+const orderedImports: RawConfig['imports'] = ['vscode', 'cursor', 'codex'];
+const rootCases: Array<{ name: string; settings: Omit<RawConfig, 'mcpServers'> }> = [
+  { name: 'canonical timeout', settings: { daemonIdleTimeoutMs: 12345, imports: orderedImports } },
+  { name: 'snake timeout', settings: { daemon_idle_timeout_ms: 67890, imports: orderedImports } },
+  {
+    name: 'both timeout spellings with distinct values',
+    settings: { daemonIdleTimeoutMs: 12345, daemon_idle_timeout_ms: 67890, imports: orderedImports },
+  },
+  { name: 'ordered imports without timeouts', settings: { imports: orderedImports } },
+  { name: 'empty imports without timeouts', settings: { imports: [] } },
+  { name: 'omitted imports and timeouts', settings: {} },
+];
+const mutations: Array<{ name: string; args: string[]; expectedServers: RawConfig['mcpServers'] }> = [
+  {
+    name: 'add new',
+    args: ['add', 'added', addedEntry.baseUrl],
+    expectedServers: { ...originalServers, added: addedEntry },
+  },
+  {
+    name: 'add replacement',
+    args: ['add', 'target', addedEntry.baseUrl],
+    expectedServers: { ...siblings, target: addedEntry },
+  },
+  { name: 'remove', args: ['remove', 'target'], expectedServers: siblings },
+  {
+    name: 'import --copy collision and new entry',
+    args: ['import', 'cursor', '--copy'],
+    expectedServers: { ...siblings, ...copiedServers },
+  },
+];
+
+describe('config mutation preservation', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe.each(rootCases)('$name', ({ settings }) => {
+    it.each(mutations)(
+      '$name preserves the complete config outside the selected entries',
+      async ({ args, expectedServers }) => {
+        const ctx = await createTempConfig({ ...settings, mcpServers: originalServers });
+        try {
+          const commandArgs = [...args];
+          if (commandArgs[0] === 'import') {
+            const importPath = path.join(ctx.tempDir, 'cursor.json');
+            await fs.writeFile(importPath, JSON.stringify({ mcpServers: copiedServers }), 'utf8');
+            commandArgs.push('--path', importPath);
+          }
+
+          await handleConfigCli({ loadOptions: ctx.loadOptions, invokeAuth: vi.fn() }, commandArgs);
+
+          const written = JSON.parse(await fs.readFile(ctx.configPath, 'utf8'));
+          expect(written).toStrictEqual({ ...settings, mcpServers: expectedServers });
+        } finally {
+          await ctx.cleanup();
+        }
+      }
+    );
+  });
+
+  it.each(['added', 'target'])('add --dry-run leaves the config bytes unchanged for %s', async (name) => {
+    const ctx = await createTempConfig({
+      mcpServers: originalServers,
+      imports: orderedImports,
+      daemonIdleTimeoutMs: 12345,
+      daemon_idle_timeout_ms: 67890,
+    });
+    try {
+      const before = await fs.readFile(ctx.configPath, 'utf8');
+
+      await handleConfigCli({ loadOptions: ctx.loadOptions, invokeAuth: vi.fn() }, [
+        'add',
+        name,
+        addedEntry.baseUrl,
+        '--dry-run',
+      ]);
+
+      expect(await fs.readFile(ctx.configPath, 'utf8')).toBe(before);
+    } finally {
+      await ctx.cleanup();
+    }
+  });
+});
+
+it.each(['daemonIdleTimeoutMs', 'daemon_idle_timeout_ms'])('still rejects zero for %s', (key) => {
+  expect(RawConfigSchema.safeParse({ mcpServers: {}, [key]: 0 }).success).toBe(false);
+});


### PR DESCRIPTION
## Summary

Fix configuration loss when server edits write a cloned config. `RawConfigSchema` accepts both `daemonIdleTimeoutMs` and `daemon_idle_timeout_ms`, but `cloneConfig` previously copied only `mcpServers` and `imports`, so successful add/remove/import-copy commands silently deleted the daemon settings.

Preserve the complete validated config before copying the server map and imports array. This fixes all three clone-backed writers without changing the schema, timeout spelling/precedence, write destinations, or whole-entry replacement semantics. The separate ad-hoc/OAuth persistence path remains unchanged.

Add real config-dispatcher/file-write regressions covering both timeout spellings separately and together, new and replacement adds, removals, import collisions, ordered/empty/omitted imports, multiple unaffected servers, and dry runs. Document the retained behavior and add an Unreleased changelog entry.

## Validation

- Real source CLI proof with isolated temporary config/root/HOME/XDG paths: all 12 mutation commands exited successfully but lost settings before the fix; the unchanged harness passes all 12 after the fix, plus schema and ad-hoc/OAuth write controls.
- New regression suite: 12 failed / 16 passed before; 28 passed after.
- `pnpm check`: passed formatting, type-aware lint, and typecheck.
- Build plus a filtered `pnpm test` run: 209 tests passed across 44 config and adjacent test files. The unrestricted local suite was intentionally not run because it launches real daemons; live tests were disabled.
- Isolated Codex autoreview: no blocking findings.

The production change is one line. No dependency, version, generated-schema, daemon, or runtime changes are included.
