### PR TITLE
test: isolate fixture startup and guarantee cleanup

### DIFF
--- a/tests/daemon-host.test.ts
+++ b/tests/daemon-host.test.ts
@@ -558,8 +558,12 @@ describeUnixSocket('runDaemonHost lifecycle', () => {
       };
       expect(metadata.relayRuntimeIdentityVersion).toBe(CHROME_DEVTOOLS_RELAY_RUNTIME_IDENTITY_VERSION);
       expect(metadata.relayRuntimeIdentity).toMatch(/^[a-f0-9]{16}$/u);
+      const shutdownComplete = new Promise<void>((resolve) => {
+        exitSpy.mockImplementation((() => resolve()) as never);
+      });
       await requestDaemon<boolean>(socketPath, { id: 'stop-relay', method: 'stop', params: {} });
-      await waitForMissing(metadataPath);
+      await shutdownComplete;
+      await expect(fs.access(metadataPath)).rejects.toMatchObject({ code: 'ENOENT' });
     } finally {
       exitSpy.mockRestore();
       for (const signal of ['SIGINT', 'SIGTERM', 'SIGQUIT'] as const) {
@@ -658,9 +662,15 @@ describeUnixSocket('runDaemonHost lifecycle', () => {
       expect(exitSpy).toHaveBeenCalledWith(0);
       expect(JSON.parse(await fs.readFile(metadataPath, 'utf8'))).toMatchObject({ pid: process.pid, socketPath });
 
+      // Metadata disappears before shutdown reaches process.exit; wait for the
+      // actual exit before restoring the spy, ignoring the earlier repair exit.
+      const shutdownComplete = new Promise<void>((resolve) => {
+        exitSpy.mockImplementation((() => resolve()) as never);
+      });
       const stopped = await requestDaemon<boolean>(socketPath, { id: 'stop', method: 'stop', params: {} });
       expect(stopped).toMatchObject({ id: 'stop', ok: true, result: true });
-      await waitForMissing(metadataPath);
+      await shutdownComplete;
+      await expect(fs.access(metadataPath)).rejects.toMatchObject({ code: 'ENOENT' });
       expect(exitSpy).toHaveBeenCalledWith(0);
     } finally {
       exitSpy.mockRestore();
@@ -933,16 +943,4 @@ async function requestDaemon<T>(socketPath: string, request: DaemonRequest, spli
     socket.once('end', () => resolve(JSON.parse(response) as DaemonResponse<T>));
     socket.once('error', reject);
   });
-}
-
-async function waitForMissing(filePath: string): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    try {
-      await fs.access(filePath);
-    } catch {
-      return;
-    }
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
-  }
-  throw new Error(`Timed out waiting for ${filePath} to be removed.`);
 }

--- a/tests/e2e-fixture-servers.test.ts
+++ b/tests/e2e-fixture-servers.test.ts
@@ -13,9 +13,9 @@ import { Client as LegacyClient } from '@modelcontextprotocol/sdk/client/index.j
 import { StreamableHTTPClientTransport as LegacyHttpTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ServerDefinition } from '../src/config.js';
-import { waitForChildExit } from '../src/process-utils.js';
 import { createRuntime } from '../src/runtime.js';
 import { makeShortTempDir } from './fixtures/test-helpers.js';
+import { closeFixtureResources, stopFixtureChild as stopChild } from './helpers/fixture-lifecycle.js';
 import { budget } from './helpers/timing.js';
 
 // These tests spawn the real CLI repeatedly, and Windows pays a far higher
@@ -66,8 +66,7 @@ beforeAll(async () => {
 }, budget(20_000));
 
 afterAll(async () => {
-  await delayedLegacyHeadersProxy.close();
-  await Promise.allSettled([...spawnedChildren].map((child) => stopChild(child)));
+  await closeFixtureResources(delayedLegacyHeadersProxy, spawnedChildren);
 });
 
 // Each real CLI invocation over stdio owns a fresh fixture process. Keep the
@@ -599,17 +598,6 @@ function trackChild(child: ChildProcess): ChildProcess {
   spawnedChildren.add(child);
   child.once('exit', () => spawnedChildren.delete(child));
   return child;
-}
-
-async function stopChild(child: ChildProcess | undefined): Promise<void> {
-  if (!child || child.exitCode !== null || child.signalCode !== null) return;
-  child.kill('SIGTERM');
-  try {
-    await waitForChildExit(child, budget(2_000));
-  } catch {
-    child.kill('SIGKILL');
-    await waitForChildExit(child, budget(2_000)).catch(() => {});
-  }
 }
 
 async function readDaemonLogs(root: string): Promise<string> {

--- a/tests/fixture-lifecycle.test.ts
+++ b/tests/fixture-lifecycle.test.ts
@@ -1,0 +1,61 @@
+import { execFile, spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { makeShortTempDir } from './fixtures/test-helpers.js';
+import { closeFixtureResources, stopFixtureChild } from './helpers/fixture-lifecycle.js';
+
+const execFileAsync = promisify(execFile);
+const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
+
+describe('fixture lifecycle', () => {
+  it.each(['missing', 'rejecting'] as const)('stops children with a %s proxy', async (kind) => {
+    const child = spawn(process.execPath, ['-e', "process.send('ready'); setInterval(() => {}, 1_000)"], {
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+    });
+    const failure = new Error('proxy close failed');
+    const proxy =
+      kind === 'missing'
+        ? undefined
+        : {
+            close: async () => {
+              throw failure;
+            },
+          };
+    try {
+      await new Promise<void>((resolve, reject) => {
+        child.once('message', () => resolve());
+        child.once('error', reject);
+      });
+      const closing = closeFixtureResources(proxy, new Set([child]));
+      if (kind === 'rejecting') await expect(closing).rejects.toBe(failure);
+      else await expect(closing).resolves.toBeUndefined();
+      expect(child.exitCode !== null || child.signalCode !== null).toBe(true);
+    } finally {
+      await stopFixtureChild(child);
+    }
+  });
+
+  it('runs TypeScript children without a persistent transform cache', async () => {
+    const directory = await makeShortTempDir('fixture-cache');
+    const sourcePath = path.join(directory, 'fixture.ts');
+    await fs.writeFile(sourcePath, 'const answer: number = 42; console.log(answer);\n');
+    try {
+      const result = await execFileAsync(process.execPath, [TSX_CLI, sourcePath], {
+        env: { ...process.env, TMPDIR: directory, TMP: directory, TEMP: directory },
+      });
+      expect(result.stdout.trim()).toBe('42');
+      const user = process.geteuid ? process.geteuid() : os.userInfo().username;
+      const entries = await fs.readdir(path.join(directory, `tsx-${user}`)).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return [];
+        throw error;
+      });
+      expect(entries).toEqual([]);
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/helpers/fixture-lifecycle.ts
+++ b/tests/helpers/fixture-lifecycle.ts
@@ -1,0 +1,27 @@
+import type { ChildProcess } from 'node:child_process';
+import { waitForChildExit } from '../../src/process-utils.js';
+import { budget } from './timing.js';
+
+export async function closeFixtureResources(
+  proxy: { close(): Promise<void> } | undefined,
+  children: ReadonlySet<ChildProcess>
+): Promise<void> {
+  // A proxy can fail to close or wait for an upstream child to exit.
+  const stoppedChildren = Promise.allSettled([...children].map((child) => stopFixtureChild(child)));
+  try {
+    await proxy?.close();
+  } finally {
+    await stoppedChildren;
+  }
+}
+
+export async function stopFixtureChild(child: ChildProcess | undefined): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  try {
+    await waitForChildExit(child, budget(2_000));
+  } catch {
+    child.kill('SIGKILL');
+    await waitForChildExit(child, budget(2_000)).catch(() => {});
+  }
+}

--- a/tests/setup/isolate-home.ts
+++ b/tests/setup/isolate-home.ts
@@ -33,6 +33,10 @@ process.env.XDG_DATA_HOME = path.join(root, '.local', 'share');
 process.env.XDG_STATE_HOME = path.join(root, '.local', 'state');
 process.env.XDG_CACHE_HOME = path.join(root, '.cache');
 
+// tsx indexes its shared disk cache at startup. Keep fixture transforms in memory
+// so unrelated projects' cache sizes cannot consume the subprocess deadlines.
+process.env.TSX_DISABLE_CACHE = '1';
+
 afterAll(() => {
   fs.rmSync(root, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Why

Test subprocess deadlines were measuring unrelated work in tsx's shared disk cache. On a long-lived development machine the cache contained 333,437 entries, and enumerating it took 19.4 seconds. The same source-renderer command took 39.7 seconds with the shared cache and 0.42 seconds with disk caching disabled. Modern fixture readiness fell from 12.8 seconds to 0.74 seconds without changing the command, protocol, or deadline. This explains the startup and record/replay timeouts: the test had barely reached the fixture, rather than hanging in replay or missing a readiness signal.

A failed HTTP-fixture startup exposed a separate teardown defect: the proxy had not been initialized, so calling its close method threw before child cleanup. A rejecting proxy close could strand children too. The daemon lifecycle tests also treated disappearance of the metadata file as completion, restoring their process.exit spy before shutdown had actually called it.

## What changes

The shared test setup disables only tsx's persistent disk cache for test subprocesses. Tests still use the real tsx loader and its in-memory transforms. No user cache is deleted, and production runtime behavior, dependencies, and all existing timeout values are unchanged.

Fixture teardown now starts child cleanup independently, tolerates a missing proxy, and awaits child termination even when proxy close rejects. The E2E suite uses this helper instead of duplicating cleanup. Daemon lifecycle tests wait for the actual exit callback, replacing metadata polling.

Three regressions exercise real child processes and TypeScript execution: missing proxy, rejecting proxy, and absence of persistent transform-cache files. All three failed against the previous behavior and pass with the fix. Existing CLI, daemon, and replay integration coverage remains intact.

## Verification

| Full suite | Passed | Failed | Skipped | Duration |
| --- | ---: | ---: | ---: | ---: |
| Before (main b3f676d) | 1,625 | 17 | 53 | 669.58s |
| After | 1,672 | 0 | 26 | 326.02s |

Before: 186 files passed, 9 failed, 4 skipped. After: 196 files passed, 0 failed, 4 skipped. The 27 tests previously skipped by failed fixture setup now run, and the three new regressions pass. Both runs used the same busy shared host; wall time is observational, not a controlled performance benchmark.

Both full runs use `pnpm test --maxWorkers=2` on Node 24.20.0 and pnpm 10.34.5, based on main b3f676d. The focused real-CLI/fixture/daemon/replay run passed 87 tests with one existing skip across six files. `pnpm check` and Codex autoreview (default P0 threshold) passed.

This is test-infrastructure-only work; no changelog or release artifacts change.
