### PR TITLE
fix(generate-cli): preserve unusual schema names without option collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### CLI
 
+- Preserve dotted tool names and HTTP selector query parameters, including configured-server headers and OAuth settings. (PR #333, thanks @Yigtwxx)
+- Generate valid, distinct flags and property accesses for unusual schema names, preserve nullable-array item types, and normalize output schema titles into TypeScript identifiers. (PR #332, thanks @Yigtwxx)
 - Preserve top-level daemon idle timeout settings when adding, removing, or copying config server entries.
 
 ### Maintenance

--- a/docs/cli-generator.md
+++ b/docs/cli-generator.md
@@ -14,6 +14,8 @@ read_when:
 - Default timeout for tool calls is 30 seconds, overridable via `--timeout`.
 - Runtime flag remains (`--runtime bun`) to tailor shebang/usage instructions, but Node.js is the default.
 - Generated CLI embeds the resolved server definition and always targets that snapshot (no external `--config` or `--server` overrides at runtime).
+- Schema property names become long flags: `QueryText` becomes `--query-text`, repeated separators collapse, and names made only of separators use `--option`. Collisions receive numeric suffixes in schema order, skipping both existing flags and Commander storage keys. Use the generated help to find the assigned spelling; calls retain the original JSON property names.
+- A schema flag such as `--no-cache` takes an explicit value and is not a negated Commander option. Nullable arrays keep their item types and enum choices.
 
 ## Usage Examples
 

--- a/docs/emit-ts.md
+++ b/docs/emit-ts.md
@@ -27,6 +27,10 @@ mcporter emit-ts <server> --out linear-client.ts \
   creates.
 - `--include-optional` mirrors `mcporter list --all-parameters`, ensuring every
   parameter is shown even when optional.
+- Output schema titles are normalized to TypeScript identifiers (`Search Results`
+  becomes `SearchResults`, and `class` becomes `Class`). Titles that cannot form
+  an identifier fall back to the schema's structural display type. Named return
+  types still need their corresponding declarations in the consuming project.
 
 Outputs overwrite existing files automatically so you can regenerate artifacts
 whenever the server schema changes.

--- a/src/cli/generate/template.ts
+++ b/src/cli/generate/template.ts
@@ -8,7 +8,7 @@ import { buildToolDoc, type ToolOptionDoc } from '../list-detail-helpers.js';
 import { markExecutable } from './fs-helpers.js';
 import { renderEmbeddedHelpSource } from './template-help.js';
 import type { GeneratedOption, ToolMetadata } from './tools.js';
-import { buildEmbeddedSchemaMap } from './tools.js';
+import { buildEmbeddedSchemaMap, toCliOptionKey } from './tools.js';
 import { stableJsonStringify } from '../../stable-json.js';
 
 export interface TemplateInput {
@@ -72,7 +72,7 @@ export function renderTemplate({
   const imports = [
     "import path from 'node:path';",
     "import { fileURLToPath } from 'node:url';",
-    "import { Command } from 'commander';",
+    "import { Command, Option } from 'commander';",
     "import { createGeneratedKeepAliveRuntime, createRuntime, createServerProxy, handleDaemonCli } from 'mcporter';",
     "import { createCallResult } from 'mcporter';",
   ].join('\n');
@@ -218,6 +218,18 @@ function unwrapRawPayload(value: unknown): unknown {
 \t\treturn (value as { raw: unknown }).raw;
 \t}
 \treturn value;
+}
+
+function defineOption(flags: string, description: string, parser?: (value: string) => unknown) {
+\tconst option = new Option(flags, description);
+\tif (parser) {
+\t\toption.argParser(parser);
+\t}
+\t// Flag names come from schema property names, so a leading no- is part of the name.
+\t// Commander would otherwise read it as a negation, store the value under the stripped
+\t// name and default it to true whenever the flag is absent.
+\toption.negate = false;
+\treturn option;
 }
 
 function parseArrayOption(value: string, itemType: 'string' | 'number' | 'boolean' | 'json') {
@@ -423,6 +435,13 @@ if (process.env.MCPORTER_DISABLE_AUTORUN !== '1') {
 `;
 }
 
+// Commander stores each option under the camelCase form of its flag, and a schema property
+// name can legally produce a key no property access can spell - `2fa` is stored under `2fa`,
+// and `cmdOpts.2fa` does not parse. Those keys are read through a subscript instead.
+function propertyAccess(target: string, key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? `${target}.${key}` : `${target}[${JSON.stringify(key)}]`;
+}
+
 export function renderToolCommand(
   tool: ToolMetadata,
   defaultTimeout: number,
@@ -445,32 +464,19 @@ export function renderToolCommand(
     });
   const buildArgs = tool.options
     .map((option) => {
-      // Commander.js camelcases flag names (e.g. --relative-path => relativePath).
-      const camelCaseProp = option.cliName
-        .split('-')
-        .filter(Boolean)
-        .map((segment, index) => (index === 0 ? segment : `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`))
-        .join('');
-      const source = `cmdOpts.${camelCaseProp}`;
-      return `if (${source} !== undefined) args.${option.property} = ${source};`;
+      const source = propertyAccess('cmdOpts', toCliOptionKey(option.cliName));
+      return `if (${source} !== undefined) ${propertyAccess('args', option.property)} = ${source};`;
     })
     .join('\n\t\t');
   const requiredChecks = tool.options
     .filter((option) => option.required)
-    .map((option) => {
-      const camelCaseProp = option.cliName
-        .split('-')
-        .filter(Boolean)
-        .map((segment, index) => (index === 0 ? segment : `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`))
-        .join('');
-      return { option, camelCaseProp };
-    });
+    .map((option) => ({ option, camelCaseProp: toCliOptionKey(option.cliName) }));
   const requiredValidation =
     requiredChecks.length > 0
       ? `const missingRequired = [${requiredChecks
           .map(
             ({ option, camelCaseProp }) =>
-              `{ value: cmdOpts.${camelCaseProp}, flag: ${JSON.stringify(`--${option.cliName}`)} }`
+              `{ value: ${propertyAccess('cmdOpts', camelCaseProp)}, flag: ${JSON.stringify(`--${option.cliName}`)} }`
           )
           .join(
             ', '
@@ -525,9 +531,9 @@ ${aliasSnippet ? `\t${aliasSnippet}` : ''}\t.action(async (cmdOpts) => {
 
 function renderOption(optionDoc: ToolOptionDoc): string {
   const parser = optionParser(optionDoc.option);
-  return `\t.option(${JSON.stringify(optionDoc.flagLabel)}, ${JSON.stringify(optionDoc.description)}${
+  return `\t.addOption(defineOption(${JSON.stringify(optionDoc.flagLabel)}, ${JSON.stringify(optionDoc.description)}${
     parser ? `, ${parser}` : ''
-  })`;
+  }))`;
 }
 
 function computeRelativeStdioCwd(definition: ServerDefinition, outputPath?: string): string | null {

--- a/src/cli/generate/tools.ts
+++ b/src/cli/generate/tools.ts
@@ -1,3 +1,4 @@
+import { Option } from 'commander';
 import type { ServerToolInfo } from '../../runtime.js';
 
 export interface ToolMetadata {
@@ -102,17 +103,20 @@ export function extractOptions(tool: ServerToolInfo): GeneratedOption[] {
   // Flatten schema properties into Commander-friendly option descriptors.
   const properties = record.properties as Record<string, unknown>;
   const requiredList = Array.isArray(record.required) ? (record.required as string[]) : [];
-  return Object.entries(properties).map(([property, descriptor]) => {
+  const entries = Object.entries(properties);
+  const cliNames = assignCliNames(entries.map(([property]) => property));
+  return entries.map(([property, descriptor], index) => {
+    const cliName = cliNames[index] as string;
     const type = inferType(descriptor);
     const arrayItemType = type === 'array' ? inferArrayItemType(descriptor) : undefined;
     const enumValues = getEnumValues(descriptor);
     const defaultValue = getDescriptorDefault(descriptor);
     const formatInfo = getDescriptorFormatHint(descriptor);
-    const placeholder = buildPlaceholder(property, type, enumValues, formatInfo?.slug);
+    const placeholder = buildPlaceholder(cliName, type, enumValues, formatInfo?.slug);
     const exampleValue = buildExampleValue(property, type, enumValues, defaultValue, arrayItemType);
     return {
       property,
-      cliName: toCliOption(property),
+      cliName,
       description: getDescriptorDescription(descriptor),
       required: requiredList.includes(property),
       type,
@@ -126,6 +130,31 @@ export function extractOptions(tool: ServerToolInfo): GeneratedOption[] {
   });
 }
 
+const EMPTY_CLI_OPTION_STEM = 'option';
+
+// Reserve storage keys too: distinct flags such as --query-2 and --query2 both use query2.
+function assignCliNames(properties: string[]): string[] {
+  const natural = properties.map((property) => toCliOption(property));
+  const claimed = new Set(natural.map(toCliOptionKey));
+  const used = new Set<string>();
+  return natural.map((base) => {
+    let name = base;
+    let suffix = 2;
+    while (used.has(toCliOptionKey(name)) || (name !== base && claimed.has(toCliOptionKey(name)))) {
+      name = `${base}-${suffix}`;
+      suffix += 1;
+    }
+    used.add(toCliOptionKey(name));
+    return name;
+  });
+}
+
+export function toCliOptionKey(cliName: string): string {
+  const option = new Option(`--${cliName} <value>`);
+  option.negate = false;
+  return option.attributeName();
+}
+
 export function getEnumValues(descriptor: unknown): string[] | undefined {
   if (!descriptor || typeof descriptor !== 'object') {
     return undefined;
@@ -135,7 +164,7 @@ export function getEnumValues(descriptor: unknown): string[] | undefined {
     const values = record.enum.filter((entry): entry is string => typeof entry === 'string');
     return values.length > 0 ? values : undefined;
   }
-  if (record.type === 'array' && typeof record.items === 'object' && record.items !== null) {
+  if (isArraySchema(record) && typeof record.items === 'object' && record.items !== null) {
     const nested = record.items as Record<string, unknown>;
     if (Array.isArray(nested.enum)) {
       const values = nested.enum.filter((entry): entry is string => typeof entry === 'string');
@@ -165,7 +194,7 @@ export function buildPlaceholder(
   enumValues?: string[],
   formatSlug?: string
 ): string {
-  const normalized = property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
+  const normalized = toCliOption(property);
   if (enumValues && enumValues.length > 0) {
     // Enum members can describe an array's items, and the generated parser splits those
     // flags on commas, so keep the multi-value hint next to the choices.
@@ -340,12 +369,18 @@ export function inferType(descriptor: unknown): GeneratedOption['type'] {
   return 'unknown';
 }
 
+// `type` may be a union such as `["array", "null"]`, so ask inferType instead of comparing the
+// raw value: these container checks have to agree with the type the option is generated with.
+function isArraySchema(record: Record<string, unknown>): boolean {
+  return inferType(record) === 'array';
+}
+
 export function inferArrayItemType(descriptor: unknown): GeneratedOption['arrayItemType'] {
   if (!descriptor || typeof descriptor !== 'object') {
     return 'unknown';
   }
   const record = descriptor as Record<string, unknown>;
-  if (record.type !== 'array' || !record.items || typeof record.items !== 'object') {
+  if (!isArraySchema(record) || !record.items || typeof record.items !== 'object') {
     return 'unknown';
   }
   const items = record.items as Record<string, unknown>;
@@ -423,7 +458,20 @@ export function toProxyMethodName(toolName: string): string {
 }
 
 export function toCliOption(property: string): string {
-  return property.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`).replace(/_/g, '-');
+  const normalized = property
+    .replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`)
+    .replace(/_/g, '-')
+    // Commander derives an option's storage key by splitting the flag on dashes and
+    // upper-casing each segment, so any empty segment - a run of separators in `foo__bar`,
+    // a leading one from `Query`, a trailing one from `foo_` - makes `addOption` throw while
+    // the generated command is being built.
+    .replace(/-{2,}/g, '-')
+    .replace(/^-|-$/g, '');
+  // Every character of a property such as `___` normalizes away, and commander rejects the
+  // `--` that name would spell. The stem stands in for the whole name, so `assignCliNames`
+  // sees it before it hands out suffixes and a schema declaring `option` beside `___` still
+  // gets two distinct flags.
+  return normalized === '' ? EMPTY_CLI_OPTION_STEM : normalized;
 }
 
 export const toolsTestHelpers = {

--- a/src/cli/list-signature.ts
+++ b/src/cli/list-signature.ts
@@ -153,8 +153,85 @@ function inferReturnTypeName(schema: unknown): string | undefined {
   return inferSchemaDisplayType(schema as Record<string, unknown>);
 }
 
+const TYPE_NAME_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// A keyword is never a type reference: most of them fail to parse in a type position
+// (`Promise<class>`, `Promise<keyof>`), and the ones TypeScript reads as keyword types
+// (`Promise<void>`, `Promise<string>`) no longer describe what the title said. Both spellings
+// have to be folded like any other non-identifier. The set is measured against the parser rather
+// than assumed: `tests/emit-ts.test.ts` renders a title for every TypeScript keyword and asserts
+// the emitted module still parses.
+const RESERVED_TYPE_NAMES = new Set([
+  'any',
+  'await',
+  'bigint',
+  'boolean',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'infer',
+  'instanceof',
+  'keyof',
+  'never',
+  'new',
+  'null',
+  'number',
+  'object',
+  'readonly',
+  'return',
+  'string',
+  'super',
+  'switch',
+  'symbol',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'undefined',
+  'unique',
+  'unknown',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
+
+// A schema title is prose, but this value is emitted as a TypeScript type name by `emit-ts`,
+// so anything that is not already an identifier has to be folded into one.
+function toTypeName(title: string): string | undefined {
+  if (TYPE_NAME_PATTERN.test(title) && !RESERVED_TYPE_NAMES.has(title)) {
+    return title;
+  }
+  const joined = title
+    .split(/[^A-Za-z0-9_$]+/)
+    .filter(Boolean)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join('');
+  return TYPE_NAME_PATTERN.test(joined) ? joined : undefined;
+}
+
 function inferSchemaDisplayType(descriptor: Record<string, unknown>): string {
-  const title = typeof descriptor.title === 'string' ? descriptor.title.trim() : undefined;
+  const title = typeof descriptor.title === 'string' ? toTypeName(descriptor.title.trim()) : undefined;
   if (title) {
     return title;
   }

--- a/tests/emit-ts.test.ts
+++ b/tests/emit-ts.test.ts
@@ -10,6 +10,92 @@ import type { Runtime } from '../src/runtime.js';
 import type { ServerToolInfo } from '../src/runtime.js';
 import { integrationDefinition, listCommentsTool } from './fixtures/tool-fixtures.js';
 
+// Every reserved word, contextual keyword and intrinsic type name TypeScript spells; a schema is
+// free to carry any of them as an `outputSchema.title`.
+const TYPESCRIPT_KEYWORDS = [
+  'abstract',
+  'accessor',
+  'any',
+  'as',
+  'asserts',
+  'async',
+  'await',
+  'bigint',
+  'boolean',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'constructor',
+  'continue',
+  'debugger',
+  'declare',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'from',
+  'function',
+  'get',
+  'global',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'infer',
+  'instanceof',
+  'interface',
+  'intrinsic',
+  'is',
+  'keyof',
+  'let',
+  'module',
+  'namespace',
+  'never',
+  'new',
+  'null',
+  'number',
+  'object',
+  'of',
+  'out',
+  'override',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'readonly',
+  'require',
+  'return',
+  'satisfies',
+  'set',
+  'static',
+  'string',
+  'super',
+  'switch',
+  'symbol',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'type',
+  'typeof',
+  'undefined',
+  'unique',
+  'unknown',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+];
+
 const dashedTool: ServerToolInfo = {
   name: 'API-post-page',
   description: 'Create a Notion page',
@@ -42,6 +128,12 @@ function createRuntimeStub(): Runtime {
     },
     close: async () => {},
   } as unknown as Runtime;
+}
+
+function parseDiagnosticsOf(source: string): string[] {
+  const parsed = ts.createSourceFile('emit.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+  const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  return diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'));
 }
 
 describe('emit-ts templates', () => {
@@ -78,10 +170,58 @@ describe('emit-ts templates', () => {
     expect(client).toContain('proxy.aPIPostPage');
 
     for (const source of [types, client]) {
-      const parsed = ts.createSourceFile('emit.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
-      const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
-      expect(diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'))).toEqual([]);
+      expect(parseDiagnosticsOf(source)).toEqual([]);
     }
+  });
+
+  // Four cases render the same module for a different title, so the rendering lives here and each
+  // case is left with the title it is about.
+  function renderTypesForTitle(title: string): string {
+    const titledTool: ServerToolInfo = {
+      ...dashedTool,
+      name: 'search',
+      outputSchema: { title },
+    };
+    const docs = emitTsTestInternals.buildDocEntries('integration', [buildToolMetadata(titledTool)], true);
+    return renderTypesModule({
+      interfaceName: 'IntegrationTools',
+      docs,
+      metadata: {
+        server: integrationDefinition,
+        generatorLabel: 'mcporter@test',
+        generatedAt: new Date('2025-11-07T00:00:00Z'),
+      },
+    });
+  }
+
+  it('keeps a multi-word outputSchema title parseable in the emitted module', () => {
+    const types = renderTypesForTitle('Search Results');
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
+    expect(types).toContain('Promise<SearchResults>');
+  });
+
+  it('keeps a reserved-word outputSchema title parseable in the emitted module', () => {
+    const types = renderTypesForTitle('class');
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
+    expect(types).toContain('Promise<Class>');
+  });
+
+  it('keeps a type-context keyword outputSchema title parseable in the emitted module', () => {
+    const types = renderTypesForTitle('keyof');
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
+    expect(types).toContain('Promise<Keyof>');
+  });
+
+  // Which spellings TypeScript refuses in a type position is the parser's answer rather than ours,
+  // so every keyword is rendered and handed back to the parser instead of compared against a copy
+  // of the set the source keeps.
+  it.each(TYPESCRIPT_KEYWORDS)('keeps the outputSchema title %s parseable in the emitted module', (keyword) => {
+    const types = renderTypesForTitle(keyword);
+
+    expect(parseDiagnosticsOf(types)).toEqual([]);
   });
 
   it('renders client module that wraps proxy calls', () => {

--- a/tests/generate-cli-helpers.test.ts
+++ b/tests/generate-cli-helpers.test.ts
@@ -1,3 +1,5 @@
+import { Command, Option } from 'commander';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import {
   buildExampleValue,
@@ -16,6 +18,7 @@ import {
   toCliOption,
   toProxyMethodName,
 } from '../src/cli/generate/tools.js';
+import { renderToolCommand } from '../src/cli/generate/template.js';
 import type { ServerToolInfo } from '../src/runtime.js';
 
 describe('generate helpers', () => {
@@ -346,5 +349,239 @@ describe('generate helpers', () => {
         placeholder: '<fields>',
       })
     ).toBe('{"key":"value"}');
+  });
+});
+
+describe('flag names stay valid commander flags', () => {
+  it('does not leak a leading dash from an uppercase property name', () => {
+    expect(toCliOption('Query')).toBe('query');
+    expect(toCliOption('QueryText')).toBe('query-text');
+    expect(buildPlaceholder('Query', 'string')).toBe('<query>');
+    expect(buildPlaceholder('Query', 'array', ['web', 'news'])).toBe('<query:web|news,...>');
+  });
+
+  it('keeps distinct flags for property names that only differ by the no- prefix', () => {
+    expect(toCliOption('no_cache')).toBe('no-cache');
+    expect(toCliOption('nocache')).toBe('nocache');
+    expect(buildPlaceholder('no_cache', 'boolean')).toBe('<no-cache:true|false>');
+  });
+
+  it('skips a suffix another property already spells', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { Query: { type: 'string' }, query: { type: 'string' }, query_2: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['query', 'query-3', 'query-2']);
+  });
+
+  it('gives a property whose characters all normalize away a usable flag name', () => {
+    expect(toCliOption('___')).toBe('option');
+    expect(toCliOption('_')).toBe('option');
+    expect(buildPlaceholder('___', 'string')).toBe('<option>');
+  });
+
+  it('assigns the fallback stem before suffixing so every name stays a long flag', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { ___: { type: 'string' }, _: { type: 'boolean' }, option: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['option', 'option-2', 'option-3']);
+  });
+
+  it('collapses a run of separators into a single dash', () => {
+    expect(toCliOption('foo__bar')).toBe('foo-bar');
+    expect(toCliOption('foo-_bar')).toBe('foo-bar');
+    expect(toCliOption('a__b__c')).toBe('a-b-c');
+    // An underscore in front of a capital spells the same run, and it is the shape a schema
+    // reaches by mixing the two conventions rather than by repeating one.
+    expect(toCliOption('filter_Query')).toBe('filter-query');
+    expect(buildPlaceholder('foo__bar', 'string')).toBe('<foo-bar>');
+  });
+
+  it('drops a trailing separator', () => {
+    expect(toCliOption('foo_')).toBe('foo');
+    expect(toCliOption('foo__')).toBe('foo');
+    // Every character still normalizing away keeps the stem rather than collapsing to nothing.
+    expect(toCliOption('_-_')).toBe('option');
+  });
+
+  it('keeps unaffected property names unchanged', () => {
+    expect(toCliOption('inputValue')).toBe('input-value');
+    expect(toCliOption('extra_path')).toBe('extra-path');
+    expect(toCliOption('nodes')).toBe('nodes');
+  });
+});
+
+function renderBlock(properties: Record<string, unknown>, required: string[]): string {
+  return renderToolCommand(
+    buildToolMetadata({ name: 'fetch', inputSchema: { type: 'object', properties, required } } as ServerToolInfo),
+    30_000,
+    'demo'
+  ).block;
+}
+
+// Mirrors defineOption in the generated module: mcporter derives flag names from schema
+// property names, so commander is told not to read a leading no- as a negation.
+function storedKey(flags: string): string {
+  const option = new Option(flags, 'Set the option.');
+  option.negate = false;
+  return option.attributeName();
+}
+
+// The generated block is spliced into a TypeScript module, so a flag name that cannot be
+// spelled as a property access has to be read through a subscript for the module to parse.
+function parseDiagnosticsOf(source: string): string[] {
+  const parsed = ts.createSourceFile('command.ts', source, ts.ScriptTarget.ES2022, false, ts.ScriptKind.TS);
+  const diagnostics = (parsed as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  return diagnostics.map((entry) => ts.flattenDiagnosticMessageText(entry.messageText, '\n'));
+}
+
+function emittedFlags(block: string): string[] {
+  return [...block.matchAll(/\.addOption\(defineOption\("([^"]+)"/g)].flatMap((match) => (match[1] ? [match[1]] : []));
+}
+
+describe('generated commands agree with commander', () => {
+  it('emits option flags commander accepts', () => {
+    const flags = emittedFlags(renderBlock({ Query: { type: 'string' } }, ['Query']));
+    expect(flags).toHaveLength(1);
+    for (const flag of flags) {
+      expect(() => new Option(flag, 'Set the option.')).not.toThrow();
+    }
+  });
+
+  it('gives every property its own flag when two spellings normalize onto one', () => {
+    const block = renderBlock(
+      {
+        Query: { type: 'string' },
+        query: { type: 'string' },
+        no_cache: { type: 'boolean' },
+        noCache: { type: 'boolean' },
+      },
+      ['Query']
+    );
+    const flags = emittedFlags(block);
+    expect(flags).toEqual([
+      '--query <query>',
+      '--query-2 <query-2>',
+      '--no-cache <no-cache:true|false>',
+      '--no-cache-2 <no-cache-2:true|false>',
+    ]);
+    // commander refuses a command that declares one flag twice, so the emitted set has to be
+    // free of duplicates before the generated module can even be loaded.
+    const command = new Command('search');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    const properties = ['Query', 'query', 'no_cache', 'noCache'];
+    properties.forEach((property, index) => {
+      expect(block).toContain(`args.${property} = cmdOpts.${storedKey(flags[index] as string)}`);
+    });
+  });
+
+  it('emits a long flag for a property whose characters all normalize away', () => {
+    const block = renderBlock({ ___: { type: 'string' }, _: { type: 'boolean' } }, ['___']);
+    const flags = emittedFlags(block);
+    expect(flags).toEqual(['--option <option>', '--option-2 <option-2:true|false>']);
+    const command = new Command('fetch');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    expect(block).toContain('args.___ = cmdOpts.option;');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
+  it('registers a flag for a property that repeats or trails a separator', () => {
+    const block = renderBlock(
+      { foo__bar: { type: 'string' }, baz_: { type: 'string' }, filter_Query: { type: 'string' } },
+      ['foo__bar']
+    );
+    const flags = emittedFlags(block);
+    expect(flags).toEqual(['--foo-bar <foo-bar>', '--baz <baz>', '--filter-query <filter-query>']);
+    // commander derives the storage key while addOption registers the flag, so an empty
+    // segment left by a dash run only surfaces here - constructing the Option alone passes.
+    const command = new Command('fetch');
+    for (const flag of flags) {
+      const option = new Option(flag, 'Set the option.');
+      option.negate = false;
+      expect(() => command.addOption(option)).not.toThrow();
+    }
+    expect(block).toContain('args.foo__bar = cmdOpts.fooBar;');
+    expect(block).toContain('args.baz_ = cmdOpts.baz;');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
+  it('keeps distinct flags for two spellings that collapse onto one', () => {
+    const names = extractOptions({
+      name: 'search',
+      inputSchema: {
+        type: 'object',
+        properties: { foo__bar: { type: 'string' }, foo_bar: { type: 'string' } },
+        required: [],
+      },
+    } as ServerToolInfo).map((option) => option.cliName);
+    expect(names).toEqual(['foo-bar', 'foo-bar-2']);
+  });
+
+  it('emits a parseable command for a flag commander stores under a non-identifier key', () => {
+    const block = renderBlock({ '2fa': { type: 'string' } }, ['2fa']);
+    expect(emittedFlags(block)).toEqual(['--2fa <2fa>']);
+    expect(block).toContain('args["2fa"] = cmdOpts["2fa"];');
+    expect(parseDiagnosticsOf(block)).toEqual([]);
+  });
+
+  it('reads every option from the key commander stores it under', () => {
+    const block = renderBlock(
+      { no_cache: { type: 'boolean' }, nocache: { type: 'boolean' }, url: { type: 'string' } },
+      ['no_cache', 'url']
+    );
+    const flags = emittedFlags(block);
+    expect(flags).toHaveLength(3);
+    expect(new Set(flags).size).toBe(3);
+    for (const flag of flags) {
+      expect(block).toContain(`cmdOpts.${storedKey(flag)}`);
+    }
+  });
+});
+
+function buildSourcesOption(type: unknown): unknown {
+  return extractOptions({
+    name: 'search',
+    inputSchema: {
+      type: 'object',
+      properties: { sources: { type, items: { type: 'string', enum: ['web', 'news'] } } },
+      required: [],
+    },
+  } as ServerToolInfo)[0];
+}
+
+describe('nullable array schemas keep their array shape', () => {
+  const nullableEnumArray = {
+    type: ['array', 'null'],
+    items: { type: 'string', enum: ['web', 'news'] },
+  };
+
+  it('resolves item types through a nullable array container', () => {
+    expect(inferArrayItemType(nullableEnumArray)).toBe('string');
+    expect(inferArrayItemType({ type: ['array', 'null'], items: { type: 'number' } })).toBe('number');
+  });
+
+  it('resolves enum members through a nullable array container', () => {
+    expect(getEnumValues(nullableEnumArray)).toEqual(['web', 'news']);
+  });
+
+  it('renders the same option for a nullable array as for a plain array', () => {
+    expect(buildSourcesOption(['array', 'null'])).toEqual(buildSourcesOption('array'));
   });
 });

--- a/tests/generate-cli-option-collisions.test.ts
+++ b/tests/generate-cli-option-collisions.test.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { expect, it } from 'vitest';
+import { generateCli } from '../src/generate-cli.js';
+
+const execFileAsync = promisify(execFile);
+
+it('keeps colliding flags and Commander storage keys independent in a generated CLI', async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-option-keys-'));
+  const fixture = path.join(directory, 'server.mjs');
+  const bundle = path.join(directory, 'cli.mjs');
+  const properties = Object.fromEntries(
+    ['Query', 'query', 'query_2', 'query3', 'no_cache', 'nocache'].map((name) => [name, { type: 'string' }])
+  );
+  await fs.writeFile(
+    fixture,
+    `
+import readline from 'node:readline';
+readline.createInterface({ input: process.stdin }).on('line', line => {
+  const request = JSON.parse(line);
+  if (request.id === undefined) return;
+  let result;
+  if (request.method === 'initialize') {
+    result = { protocolVersion: request.params.protocolVersion, capabilities: { tools: {} }, serverInfo: { name: 'collision', version: '1' } };
+  } else if (request.method === 'tools/list') {
+    result = { tools: [{ name: 'echo', inputSchema: { type: 'object', properties: ${JSON.stringify(properties)}, required: ['Query', 'query'] } }] };
+  } else {
+    result = { content: [{ type: 'text', text: JSON.stringify(request.params.arguments) }] };
+  }
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) + '\\n');
+});
+`
+  );
+  try {
+    await generateCli({
+      serverRef: JSON.stringify({ name: 'collision', command: process.execPath, args: [fixture] }),
+      runtime: 'node',
+      bundler: 'rolldown',
+      bundle,
+      timeoutMs: 5_000,
+    });
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        bundle,
+        'echo',
+        '--query',
+        'uppercase',
+        '--query-4',
+        'lowercase',
+        '--query-2',
+        'suffix',
+        '--query3',
+        'natural',
+        '--no-cache',
+        'explicit',
+        '--nocache',
+        'plain',
+      ],
+      { timeout: 10_000 }
+    );
+    expect(JSON.parse(stdout)).toEqual({
+      Query: 'uppercase',
+      query: 'lowercase',
+      query_2: 'suffix',
+      query3: 'natural',
+      no_cache: 'explicit',
+      nocache: 'plain',
+    });
+    const absent = await execFileAsync(
+      process.execPath,
+      [bundle, 'echo', '--query', 'uppercase', '--query-4', 'lowercase'],
+      { timeout: 10_000 }
+    );
+    expect(JSON.parse(absent.stdout)).toEqual({ Query: 'uppercase', query: 'lowercase' });
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+}, 30_000);

--- a/tests/generate-cli.test.ts
+++ b/tests/generate-cli.test.ts
@@ -655,7 +655,7 @@ describeGenerateCli('generateCli', () => {
       includeTools: ['set_cells_batch'],
     });
     const content = await fs.readFile(renderedPath, 'utf8');
-    expect(content).toContain('.option("--cells <cells:value1,value2>"');
+    expect(content).toContain('defineOption("--cells <cells:value1,value2>"');
     expect(content).not.toContain('.requiredOption("--cells');
 
     const { execFile } = await import('node:child_process');


### PR DESCRIPTION
Generated CLIs can fail at startup or silently send the wrong argument when legal schema property names produce invalid flags or collide. This integrates @Yigtwxx's #332 fixes and closes the remaining Commander storage-key collision found during release review.

The contributor's normalization, explicit handling of `--no-` flags, safe property access, nullable-array inference, and output-title normalization are preserved. Flag allocation now reserves Commander's actual attribute names as well: `--query-3` and `--query3` must not share `query3`. The template uses the same helper for argument reads and required-field checks, removing two independent copies of that rule.

A generated-CLI regression starts a real stdio fixture, bundles the CLI, invokes it with colliding names, verifies every original JSON field independently, and checks that omitted optional flags stay absent. Documentation explains assigned flag names and the existing named-return-type declaration requirement. The changelog credits #332 and the separately merged #333.

Validation: contributor regression cases reproduced on current main; `pnpm check`; the 119 focused tests; built-CLI stdio/HTTP, generated-bundle, nullable-array and emitted-TypeScript syntax proof; isolated Codex autoreview. Full-suite and exact-head CI results are recorded below before merge.

Supersedes #332 after this integration is green and merged. Thank you @Yigtwxx for the fixes and extensive regression coverage.
