### PR TITLE
fix(oauth): listen for openExternal spawn errors on darwin and win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### OAuth
 
-- Swallow spawn errors from the macOS `open` and Windows `rundll32` browser helpers so a missing helper cannot crash `mcporter auth`.
+- Keep OAuth running when macOS `open` or Windows `rundll32` cannot start, so the printed authorization URL remains usable. (PR #341, thanks @SebTardif)
 
 ### Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.9] - Unreleased
 
+### OAuth
+
+- Swallow spawn errors from the macOS `open` and Windows `rundll32` browser helpers so a missing helper cannot crash `mcporter auth`.
+
 ### Maintenance
 
 - Refresh runtime schema validation and generated CLI bundling dependencies, including Zod's reserved-key parsing fixes, while preserving the 48-hour dependency release-age policy.

--- a/docs/adhoc.md
+++ b/docs/adhoc.md
@@ -60,6 +60,8 @@ The CLI still avoids surprise prompts during `mcporter list`; the upgrade happen
 
 ## Auth & Persistence
 
+Browser launch is best-effort: if the system browser helper cannot start, mcporter keeps the OAuth session running and prints the authorization URL for you to open manually.
+
 - OAuth flows are allowed; successful tokens store under the inferred name just like regular definitions.
 - `mcporter auth` accepts the same `--http-url/--stdio` flags (and even bare URLs), so you can immediately re-run `mcporter auth https://…` after a 401 without touching a config file.
 - Use `mcporter auth <url> --no-browser` for human-in-the-loop headless OAuth. Text mode writes only the authorization URL to stdout; `--json --no-browser` writes `authorizationUrl` plus `redirectUrl` as JSON. Keep that URL out of durable CI logs and support bundles. The `mcporter auth` process must keep running until the browser redirects to `redirectUrl`; process managers that capture stdout and then tear down the command can kill the local callback listener before tokens are saved. Use a persistent terminal, `tmux`, or a supervised background process such as `nohup` when completing OAuth outside an interactive shell.

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -122,6 +122,7 @@ function openExternal(url: string, platform: NodeJS.Platform = process.platform,
   try {
     if (platform === 'darwin') {
       const child = launch('open', [url], { stdio, detached: true });
+      child.on('error', () => {}); // swallow ENOENT when `open` is missing
       child.unref();
     } else if (platform === 'win32') {
       // Shell-free: do not pass the OAuth URL through cmd.exe. Command metacharacters
@@ -132,6 +133,7 @@ function openExternal(url: string, platform: NodeJS.Platform = process.platform,
         detached: true,
         windowsHide: true,
       });
+      child.on('error', () => {}); // swallow ENOENT when rundll32 is missing
       child.unref();
     } else {
       try {

--- a/tests/oauth-open-external-process.integration.test.ts
+++ b/tests/oauth-open-external-process.integration.test.ts
@@ -1,0 +1,46 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
+
+const runNode = promisify(execFile);
+const oauthModule = new URL('../dist/oauth.js', import.meta.url);
+
+beforeAll(async () => {
+  await ensureDistBuilt(fileURLToPath(oauthModule));
+});
+
+describe('browser helper spawn failures in a real process', () => {
+  it.each(['darwin', 'win32', 'linux'] as const)('survives an asynchronous %s ENOENT', async (platform) => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-browser-error-'));
+    try {
+      const script = `
+        import { spawn } from 'node:child_process';
+        import { __oauthInternals } from ${JSON.stringify(oauthModule.href)};
+        const keepAlive = setTimeout(() => {}, 10_000);
+        let child;
+        __oauthInternals.openExternal('https://example.com/auth', ${JSON.stringify(platform)},
+          (_command, args, options) => {
+            child = spawn(${JSON.stringify(path.join(tempDir, 'missing-helper'))}, args, options);
+            return child;
+          });
+        // Do not register an error listener here: production must handle it.
+        await new Promise(resolve => child.once('close', resolve));
+        clearTimeout(keepAlive);
+        console.log('survived browser helper failure');
+      `;
+      const { stdout, stderr } = await runNode(process.execPath, ['--input-type=module', '--eval', script], {
+        timeout: budget(10_000),
+      });
+      expect(stdout.trim()).toBe('survived browser helper failure');
+      expect(stderr).toBe('');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -42,6 +42,82 @@ describe('openExternal', () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
+  it('swallows open error events on darwin', () => {
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+
+    expect(() =>
+      __oauthInternals.openExternal(
+        'https://example.com/auth',
+        'darwin',
+        launch as unknown as typeof import('node:child_process').spawn
+      )
+    ).not.toThrow();
+    expect(launch).toHaveBeenCalledWith('open', ['https://example.com/auth'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    expect(child.listenerCount('error')).toBeGreaterThan(0);
+    expect(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).not.toThrow();
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it('swallows rundll32 error events on win32', () => {
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+    const url = 'https://example.com/auth?client_id=abc&redirect_uri=http://127.0.0.1:1234/callback';
+
+    expect(() =>
+      __oauthInternals.openExternal(url, 'win32', launch as unknown as typeof import('node:child_process').spawn)
+    ).not.toThrow();
+    expect(launch).toHaveBeenCalledWith('rundll32', ['url.dll,FileProtocolHandler', url], {
+      stdio: 'ignore',
+      detached: true,
+      windowsHide: true,
+    });
+    expect(child.listenerCount('error')).toBeGreaterThan(0);
+    expect(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).not.toThrow();
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it.each(['darwin', 'win32'] as const)(
+    'does not turn a late %s spawn error into an unhandled process crash',
+    async (platform) => {
+      const child = new EventEmitter() as EventEmitter & { unref: () => void };
+      child.unref = vi.fn();
+      const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+      const unhandled: unknown[] = [];
+      const record = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', record);
+      process.on('uncaughtException', record);
+      try {
+        __oauthInternals.openExternal(
+          'https://example.com/auth',
+          platform,
+          launch as unknown as typeof import('node:child_process').spawn
+        );
+        await new Promise<void>((resolve) => {
+          setImmediate(() => {
+            try {
+              child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }));
+            } catch (error) {
+              unhandled.push(error);
+            }
+            resolve();
+          });
+        });
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', record);
+        process.off('uncaughtException', record);
+      }
+    }
+  );
+
   it('opens the browser via rundll32 FileProtocolHandler on Windows (no cmd.exe)', () => {
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
     child.unref = vi.fn();

--- a/tests/oauth-open-external.test.ts
+++ b/tests/oauth-open-external.test.ts
@@ -82,42 +82,6 @@ describe('openExternal', () => {
     expect(child.unref).toHaveBeenCalled();
   });
 
-  it.each(['darwin', 'win32'] as const)(
-    'does not turn a late %s spawn error into an unhandled process crash',
-    async (platform) => {
-      const child = new EventEmitter() as EventEmitter & { unref: () => void };
-      child.unref = vi.fn();
-      const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
-      const unhandled: unknown[] = [];
-      const record = (reason: unknown) => {
-        unhandled.push(reason);
-      };
-      process.on('unhandledRejection', record);
-      process.on('uncaughtException', record);
-      try {
-        __oauthInternals.openExternal(
-          'https://example.com/auth',
-          platform,
-          launch as unknown as typeof import('node:child_process').spawn
-        );
-        await new Promise<void>((resolve) => {
-          setImmediate(() => {
-            try {
-              child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }));
-            } catch (error) {
-              unhandled.push(error);
-            }
-            resolve();
-          });
-        });
-        expect(unhandled).toEqual([]);
-      } finally {
-        process.off('unhandledRejection', record);
-        process.off('uncaughtException', record);
-      }
-    }
-  );
-
   it('opens the browser via rundll32 FileProtocolHandler on Windows (no cmd.exe)', () => {
     const child = new EventEmitter() as EventEmitter & { unref: () => void };
     child.unref = vi.fn();


### PR DESCRIPTION
A failed macOS `open` or Windows `rundll32` spawn can emit an asynchronous child-process error after `openExternal` returns. Without an error listener, Node terminates OAuth even though mcporter prints a manual authorization URL. Attach the same listener already used for Linux so the existing manual flow remains usable; browser arguments, shell-free Windows launching, and `--no-browser` behavior are unchanged.

Thanks @SebTardif for the fix. The maintainer follow-up replaces simulated late-error/global-process handlers with regressions in real Node subprocesses, documents the manual fallback, and adds contributor credit to the changelog.

On Node 24.20.0 / pnpm 10.34.5, `pnpm check` and `pnpm test` pass: 1,796 tests passed, 26 skipped. Independent built-runtime proof compares the original baseline `ab0c27f03fd7d27aa5b48774ac749a4548836234` with this candidate:

- The Darwin and Windows branches exit 1 with an unhandled ENOENT on base and exit 0 with the fix, using real missing child executables. Linux remains successful in both revisions.
- On native macOS with an empty executable search path, the built OAuth provider crashes on base when `open` is missing. The fixed provider retains the printed manual URL, accepts a real HTTP request to its localhost callback, and returns the synthetic authorization code. Its callback server is then closed.

Only synthetic data and local processes were used. The Windows branch was exercised on macOS here; cross-platform CI runs the maintained process regressions natively. This does not claim a complete Windows browser/authorization-server session.

Full-candidate isolated Codex review (original patch plus maintainer changes) found no actionable P0–P2 issues. The contributor's original commit is preserved; the maintainer follow-up carries a co-author trailer.

The existing contributor branch was reconciled with main after #343 by a normal merge commit, preserving all contributor history. Frozen install/build, all nine focused OAuth regressions, real missing-executable checks, and the native macOS provider callback proof pass again with the updated dependencies. Full combined P0–P2 reviews before the integration commit and landing found no actionable issues.

Final head: `e0ceb538c047e7b0ab2596f8e77a19af1bbbe2b2`; base: `e212368533bc0bdd94b5a3c89866fd912431d83c`. [CI](https://github.com/openclaw/mcporter/actions/runs/33857005091) passed on Ubuntu, macOS 15, and Windows, including the full suites and real-process regressions. No CI retries were needed.
