### PR TITLE
fix(env): clean up overrides when setup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.13.9] - Unreleased
 
+### Reliability
+
+- Remove temporary environment overrides when a later value fails validation or resolution, preventing failed setup from affecting subsequent MCP connections. (PR #342, thanks @oodadoudou)
+
 ### Maintenance
 
 - Refresh runtime schema validation and generated CLI bundling dependencies, including Zod's reserved-key parsing fixes, while preserving the 48-hour dependency release-age policy.

--- a/docs/config.md
+++ b/docs/config.md
@@ -272,5 +272,6 @@ For keep-alive stdio servers, refresh happens before process start. If that proc
 
 - `mcporter list --http-url ...` refuses to auto-run OAuth to keep listing commands quick; use `mcporter config login ...` or `mcporter auth ...` to finish credential setup.
 - When env placeholders are missing, commands fail fast with the exact variable name. Add the variable or wrap it in `${VAR:-fallback}` to provide defaults.
+- Temporary server environment overrides are removed after connection setup, including when a later override fails validation or resolution. Values inherited from the process keep their existing precedence.
 - Use `mcporter config get <name>` to confirm where a server came from. If a teammate’s Cursor config keeps overriding your local entry, reorder the `imports` array to move Cursor later or set it to `[]` to disable imports entirely.
 - `docs/adhoc.md` covers deeper debugging, including tmux workflows and OAuth promotion logs.

--- a/src/env.ts
+++ b/src/env.ts
@@ -106,20 +106,20 @@ export async function withEnvOverrides<T>(
   }
 
   const applied: string[] = [];
-  for (const [key, rawValue] of Object.entries(envOverrides)) {
-    rejectUnsupportedBracedEnvPlaceholder(rawValue);
-    if (process.env[key]) {
-      continue;
-    }
-    const resolved = resolveEnvValue(rawValue);
-    if (resolved === '') {
-      continue;
-    }
-    process.env[key] = resolved;
-    applied.push(key);
-  }
-
   try {
+    for (const [key, rawValue] of Object.entries(envOverrides)) {
+      rejectUnsupportedBracedEnvPlaceholder(rawValue);
+      if (process.env[key]) {
+        continue;
+      }
+      const resolved = resolveEnvValue(rawValue);
+      if (resolved === '') {
+        continue;
+      }
+      process.env[key] = resolved;
+      applied.push(key);
+    }
+
     return await fn();
   } finally {
     for (const key of applied) {

--- a/tests/env-and-daemon-utils.test.ts
+++ b/tests/env-and-daemon-utils.test.ts
@@ -76,6 +76,23 @@ describe('environment helpers', () => {
       withEnvOverrides({ MCPORTER_EXISTING: '${env:MCPORTER_EXISTING}' }, async () => 'unreachable')
     ).rejects.toThrow("Unsupported environment placeholder '${env:MCPORTER_EXISTING}'");
   });
+
+  it.each([
+    ['${env:MCPORTER_REQUIRED}', 'Unsupported environment placeholder'],
+    ['$env:MCPORTER_REQUIRED', "Environment variable 'MCPORTER_REQUIRED' is required"],
+  ])('cleans up earlier overrides when setup rejects %s', async (invalidValue, message) => {
+    delete process.env.MCPORTER_TEMP;
+    delete process.env.MCPORTER_REQUIRED;
+    delete process.env.MCPORTER_INVALID;
+    const task = vi.fn();
+
+    await expect(
+      withEnvOverrides({ MCPORTER_TEMP: 'temporary', MCPORTER_INVALID: invalidValue }, task)
+    ).rejects.toThrow(message);
+
+    expect(task).not.toHaveBeenCalled();
+    expect(process.env.MCPORTER_TEMP).toBeUndefined();
+  });
 });
 
 describe('daemon request utilities', () => {

--- a/tests/env-and-daemon-utils.test.ts
+++ b/tests/env-and-daemon-utils.test.ts
@@ -84,14 +84,20 @@ describe('environment helpers', () => {
     delete process.env.MCPORTER_TEMP;
     delete process.env.MCPORTER_REQUIRED;
     delete process.env.MCPORTER_INVALID;
+    process.env.MCPORTER_EXISTING = 'original';
     const task = vi.fn();
 
     await expect(
-      withEnvOverrides({ MCPORTER_TEMP: 'temporary', MCPORTER_INVALID: invalidValue }, task)
+      withEnvOverrides(
+        { MCPORTER_EXISTING: 'replacement', MCPORTER_TEMP: 'temporary', MCPORTER_INVALID: invalidValue },
+        task
+      )
     ).rejects.toThrow(message);
 
     expect(task).not.toHaveBeenCalled();
     expect(process.env.MCPORTER_TEMP).toBeUndefined();
+    expect(process.env.MCPORTER_INVALID).toBeUndefined();
+    expect(process.env.MCPORTER_EXISTING).toBe('original');
   });
 });
 


### PR DESCRIPTION
When a server's later environment value fails validation or resolution, `withEnvOverrides` previously threw before entering its cleanup block. Earlier temporary writes remained in the parent process and could be inherited by the next MCP subprocess even though the failed connection callback never ran.

Move the setup loop inside the existing `try/finally`, retaining inherited-value precedence and cleanup ownership. Thanks @oodadoudou (JUSHUANGHUI LI) for the fix. The maintainer follow-up adds changelog credit, documents failed-setup cleanup, and checks that inherited values remain unchanged and invalid values are never applied.

On Node 24.20.0 / pnpm 10.34.5, `pnpm check` and `pnpm test` pass: 1,793 tests passed, 26 skipped. Independent proof uses built public `createRuntime()` on the original baseline `ab0c27f03fd7d27aa5b48774ac749a4548836234` and the candidate. For both unsupported `${env:VAR}` and missing `$env:VAR` forms, a failed connection is followed in the same process by a real local stdio MCP server. Initialization, tools/list, and tools/call complete successfully.

Base leaves the synthetic temporary value in the parent and the next MCP server; candidate leaves it absent in both. An inherited synthetic value stays unchanged in both revisions. The driver closes every runtime in `finally`. No transport/helper mocks, private configuration, or credentials are used.

Full-candidate isolated Codex review (original patch plus maintainer changes) found no actionable P0–P2 issues. The contributor's original commit is preserved; the maintainer follow-up carries a co-author trailer.

The existing contributor branch was reconciled with main after #343 and #341 by a normal merge commit. Both independent changelog entries and contributor history were preserved. Frozen install/build, all 19 focused environment/OAuth regressions, and the built public-runtime subprocess proof pass again on the combined candidate. Full combined P0–P2 reviews before the integration commit and landing found no actionable issues.

Final head: `8bc87249aa482e0860d7d04120d8fe4d18788838`; base: `30880f8aa17ae4c247314e2a1a0ac7b18c190cf9`. [CI](https://github.com/openclaw/mcporter/actions/runs/33857630624) passed on Ubuntu, macOS 15, and Windows, including the full suites. Fork workflow approval was granted after reviewing the exact candidate and unchanged workflow. No CI test failures or reruns were needed.
