### PR TITLE
test(http-utils): cover URL-candidate and selector error/boundary branches

### DIFF
--- a/tests/http-utils.test.ts
+++ b/tests/http-utils.test.ts
@@ -1,11 +1,44 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeHttpUrl, splitHttpToolSelector } from '../src/cli/http-utils.js';
+import {
+  looksLikeHttpUrl,
+  normalizeHttpUrl,
+  normalizeHttpUrlCandidate,
+  splitHttpToolSelector,
+} from '../src/cli/http-utils.js';
+
+describe('normalizeHttpUrlCandidate', () => {
+  it('returns undefined for missing, empty, or whitespace-only input', () => {
+    expect(normalizeHttpUrlCandidate(undefined)).toBeUndefined();
+    expect(normalizeHttpUrlCandidate('')).toBeUndefined();
+    expect(normalizeHttpUrlCandidate('   ')).toBeUndefined();
+  });
+
+  it('promotes a bare domain-with-path to an https URL', () => {
+    expect(normalizeHttpUrlCandidate('example.com/mcp')).toBe('https://example.com/mcp');
+  });
+
+  it('returns undefined for a scheme-prefixed value that is not a valid URL', () => {
+    expect(normalizeHttpUrlCandidate('https://')).toBeUndefined();
+  });
+});
+
+describe('looksLikeHttpUrl', () => {
+  it('is false for a non-URL and true for a normalizable candidate', () => {
+    expect(looksLikeHttpUrl('')).toBe(false);
+    expect(looksLikeHttpUrl('example.com/mcp')).toBe(true);
+  });
+});
 
 describe('normalizeHttpUrl', () => {
   it('uses URL serialization for origin and path forms', () => {
     expect(normalizeHttpUrl('HTTPS://WWW.Example.COM')).toBe('https://example.com/');
     expect(normalizeHttpUrl('https://www.example.com/mcp/')).toBe('https://example.com/mcp/');
     expect(normalizeHttpUrl('https://www.example.com/mcp')).toBe('https://example.com/mcp');
+  });
+
+  it('returns undefined for input that is not a parseable URL', () => {
+    expect(normalizeHttpUrl('not a url')).toBeUndefined();
+    expect(normalizeHttpUrl('')).toBeUndefined();
   });
 });
 
@@ -39,5 +72,10 @@ describe('splitHttpToolSelector', () => {
   it('still rejects a path segment without a tool suffix', () => {
     expect(splitHttpToolSelector('https://example.com/mcp')).toBeNull();
     expect(splitHttpToolSelector('https://example.com/.tool')).toBeNull();
+  });
+
+  it('rejects a selector whose tool suffix has non-identifier characters', () => {
+    expect(splitHttpToolSelector('https://example.com/mcp.to$ol')).toBeNull();
+    expect(splitHttpToolSelector('https://example.com/mcp.a b')).toBeNull();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`src/cli/http-utils.ts` holds the URL helpers behind HTTP-server target resolution: `normalizeHttpUrlCandidate` (promote/validate a user-typed target), `looksLikeHttpUrl`, `normalizeHttpUrl`, and `splitHttpToolSelector` (split a `base.tool` selector). The existing `tests/http-utils.test.ts` covered the happy paths of `normalizeHttpUrl` and `splitHttpToolSelector`, but several error/boundary branches shipped with **no coverage at any level**:

- `normalizeHttpUrlCandidate` returning `undefined` for missing / empty / whitespace-only input, and for a scheme-prefixed value that is not a valid URL (e.g. `https://`).
- `looksLikeHttpUrl` — the boolean contract on a non-URL vs a normalizable candidate.
- `normalizeHttpUrl` returning `undefined` for unparseable input.
- `splitHttpToolSelector` rejecting a tool suffix containing non-identifier characters (the `/^[A-Za-z0-9_-]+$/` guard).

A future edit to any of those branches could silently change how a mistyped or malformed HTTP target/selector is handled, with no failing test to catch it.

## Why This Change Was Made

Coverage-only. Extends `tests/http-utils.test.ts` (**+39 / −1, no production code touched**) with focused characterization tests that pin the current `main` behavior of the previously-uncovered branches. No new config, defaults, dependencies, or behavior.

## User Impact

No user-visible or runtime change. For maintainers, the URL-candidate and tool-selector rejection contracts now regress loudly instead of silently: a future edit that drops the empty/whitespace guard, the scheme-but-invalid guard, the unparseable-input guard, or the tool-suffix character check will fail this suite.

## Evidence

Linux, Node 22, `pnpm install --frozen-lockfile` from source, branched off current `main` (`9579ed6`).

**12/12 pass on clean `main`:**

```console
$ ./node_modules/.bin/vitest run tests/http-utils.test.ts
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

**These branches were genuinely uncovered — the whole suite (unit + integration) does not assert them.** Applying a combined behavior-changing mutation to exactly these branches in `src/cli/http-utils.ts` (empty/whitespace/invalid → return a non-`undefined` value; drop the tool-suffix regex) and running the **entire** test suite leaves the pass/fail count **unchanged** (same pre-existing environment-dependent failures, zero new ones) — no existing unit **or** integration test's assertion depends on these branches, including `tests/cli-http-selector.integration.test.ts`:

| Suite run under the combined mutation | New failures |
| --- | --- |
| full test suite (203 files) | 0 |

**The new tests bite — under the same mutation, this suite fails exactly on the targeted arms:**

```console
$ # combined mutation applied to src/cli/http-utils.ts
$ ./node_modules/.bin/vitest run tests/http-utils.test.ts
      Tests  5 failed | 7 passed (12)
$ # mutation reverted (src/cli/http-utils.ts byte-identical to main)
```

**Coverage of the target branches (lines 5, 9, 20, 56, 81) is now filled** — the only branches that remain uncovered afterward are the defensive/unreachable ones (a `URL` always has a pathname; the selector's `new URL` cannot throw after `normalizeHttpUrlCandidate` already validated it; `baseSegment` is non-empty whenever `dotIndex > 0`), which this suite deliberately does not target.

**Format / lint / types clean on the changed file:**

```console
$ ./node_modules/.bin/oxfmt --check tests/http-utils.test.ts        # All matched files use the correct format.
$ ./node_modules/.bin/oxlint --type-aware --tsconfig tsconfig.json --deny-warnings tests/http-utils.test.ts   # exit 0
$ ./node_modules/.bin/tsc --project tsconfig.json --noEmit          # exit 0
```

**Scope:** one existing test file extended, `+39 / −1`, no production code changed. Same accept-shape as the merged OAuth-coverage PRs #246 / #281 / #331.

_AI-assisted contribution._

<sub>Opened from an org-owned fork via the API; if GitHub's *Allow edits by maintainers* toggle isn't honored on this PR, a maintainer can still push to the branch or supersede-and-land.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_012QouxMJcq3oBcqZdS9fw4Y)_