### PR TITLE
fix(daemon): handle spawn errors on detached launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Reliability
 
+- Handle spawn errors on detached daemon launch so a missing command does not crash `mcporter daemon start` or auto-launch. Thanks @SebTardif.
 - Remove temporary environment overrides when a later value fails validation or resolution, preventing failed setup from affecting subsequent MCP connections. (PR #342, thanks @oodadoudou)
 
 ### OAuth

--- a/src/daemon/launch.ts
+++ b/src/daemon/launch.ts
@@ -33,6 +33,7 @@ export function launchDaemonDetached(options: DaemonLaunchOptions, launch: typeo
     stdio: 'ignore',
     env: invocation.env,
   });
+  child.on('error', () => {}); // swallow ENOENT when the launch command is missing
   child.unref();
 }
 

--- a/tests/daemon-launch-process.integration.test.ts
+++ b/tests/daemon-launch-process.integration.test.ts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ensureDistBuilt } from './helpers/dist.js';
+import { budget } from './helpers/timing.js';
+
+const runNode = promisify(execFile);
+const launchModule = new URL('../dist/daemon/launch.js', import.meta.url);
+
+beforeAll(async () => {
+  await ensureDistBuilt(fileURLToPath(launchModule));
+});
+
+describe('detached daemon spawn failures in a real process', () => {
+  it('survives an asynchronous ENOENT from the launch command', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-launch-error-'));
+    try {
+      const script = `
+        import { spawn } from 'node:child_process';
+        import { launchDaemonDetached } from ${JSON.stringify(launchModule.href)};
+        const keepAlive = setTimeout(() => {}, 10_000);
+        let child;
+        launchDaemonDetached({
+          configPath: ${JSON.stringify(path.join(tempDir, 'config.json'))},
+          socketPath: ${JSON.stringify(path.join(tempDir, 'daemon.sock'))},
+          metadataPath: ${JSON.stringify(path.join(tempDir, 'daemon.json'))},
+        }, (_command, args, options) => {
+          child = spawn(${JSON.stringify(path.join(tempDir, 'missing-daemon'))}, args, options);
+          return child;
+        });
+        // Do not register an error listener here: production must handle it.
+        await new Promise(resolve => child.once('close', resolve));
+        clearTimeout(keepAlive);
+        console.log('survived daemon spawn failure');
+      `;
+      const scriptPath = path.join(tempDir, 'proof.mjs');
+      await fs.writeFile(scriptPath, script);
+      const { stdout, stderr } = await runNode(process.execPath, [scriptPath], {
+        timeout: budget(10_000),
+      });
+      expect(stdout.trim()).toBe('survived daemon spawn failure');
+      expect(stderr).toBe('');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/daemon-launch.test.ts
+++ b/tests/daemon-launch.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { buildDaemonLaunchInvocation, launchDaemonDetached, type DaemonLaunchOptions } from '../src/daemon/launch.js';
@@ -13,8 +14,9 @@ const options: DaemonLaunchOptions = {
 
 describe('buildDaemonLaunchInvocation', () => {
   it('spawns and unreferences the detached daemon', () => {
-    const unref = vi.fn();
-    const launch = vi.fn(() => ({ unref }));
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
 
     launchDaemonDetached(options, launch as unknown as typeof import('node:child_process').spawn);
 
@@ -23,7 +25,20 @@ describe('buildDaemonLaunchInvocation', () => {
       expect.arrayContaining(['daemon', 'start', '--foreground']),
       expect.objectContaining({ detached: true, stdio: 'ignore' })
     );
-    expect(unref).toHaveBeenCalled();
+    expect(child.unref).toHaveBeenCalled();
+  });
+
+  it('attaches an error listener before unref so spawn failures stay handled', () => {
+    const child = new EventEmitter() as EventEmitter & { unref: () => void };
+    child.unref = vi.fn();
+    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+
+    expect(() =>
+      launchDaemonDetached(options, launch as unknown as typeof import('node:child_process').spawn)
+    ).not.toThrow();
+    expect(child.listenerCount('error')).toBeGreaterThan(0);
+    expect(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).not.toThrow();
+    expect(child.unref).toHaveBeenCalled();
   });
 
   it('launches Node entrypoints directly with the CLI script path', () => {


### PR DESCRIPTION
## What Problem This Solves

`mcporter daemon start` and `DaemonClient.ensureDaemon()` auto-launch both call `launchDaemonDetached`. That helper spawns the child with `{ detached: true, stdio: 'ignore' }` and then `unref()`s it. There is no `error` listener.

Node emits spawn failures such as ENOENT asynchronously. Without a listener, a missing launch command (stripped PATH, missing `nohup` on a compiled macOS binary, a deleted Node entry) becomes an unhandled EventEmitter error and kills the parent CLI. The wait-for-ready path never reports that the daemon did not start.

This is the same class as #341 for `openExternal`. Attach `child.on('error', ...)` before `unref()` so the parent stays alive and wait-for-ready can fail.

## Evidence

On Node v24.19.0, a detached spawn of a path that does not exist, followed by `unref()` and no error listener, terminates the process:

```console
$ node proof-daemon-unfixed.mjs
node:events:487
      throw er; // Unhandled 'error' event
      ^

Error: spawn C:\Users\sebta\AppData\Local\Temp\mcporter-missing-daemon-helper ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:287:19)
    at onErrorNT (node:internal/child_process:525:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
    at onErrorNT (node:internal/child_process:525:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn C:\\Users\\sebta\\AppData\\Local\\Temp\\mcporter-missing-daemon-helper',
  path: 'C:\\Users\\sebta\\AppData\\Local\\Temp\\mcporter-missing-daemon-helper',
  spawnargs: [ 'daemon', 'start', '--foreground' ]
}

UNFIXED_EXIT=1
```

The same missing command through production `launchDaemonDetached` from `dist/daemon/launch.js` stays in-process:

```console
$ node proof-daemon-fixed.mjs
survived daemon spawn failure
import file:///C:/Users/sebta/.grok/tmp/pr-gate-batch/mcporter-f005/dist/daemon/launch.js
FIXED_NODE_EXIT=0
```

## Real behavior proof

- **Behavior or issue addressed:** Detached daemon spawn ENOENT no longer becomes an unhandled EventEmitter crash in the parent CLI used by `mcporter daemon start` and auto-launch.
- **Real environment tested:** Windows, Node v24.19.0, compiled `dist/daemon/launch.js` from this branch.
- **Exact steps or command run after this patch:** `node` imported production `launchDaemonDetached` and pointed the launch callback at a missing helper path, then waited for the child `close` event without registering an extra error listener.
- **Evidence after fix:** terminal output above. The process printed `survived daemon spawn failure` and exited 0.
- **Observed result after fix:** The parent stayed alive after the missing-command spawn. Wait-for-ready can time out instead of the CLI dying on an unhandled error.
- **What was not tested:** A full `mcporter daemon start` session against a stripped PATH on a compiled macOS Bun binary (`nohup` wrap).

Same-repo prior art: #341 (`openExternal` error listeners). No open competing PR for `launchDaemonDetached`.
