### PR TITLE
test(daemon): stabilize singleton fixture readiness and timing

### DIFF
--- a/tests/singleton-chrome-relay.test.ts
+++ b/tests/singleton-chrome-relay.test.ts
@@ -12,6 +12,10 @@ import { fixtureResult } from './helpers/singleton.js';
 import { generateCli } from '../src/generate-cli.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { budget } from './helpers/timing.js';
+
+// These end-to-end cases launch processes and bundle a CLI; Windows needs the shared spawn budget.
+vi.setConfig({ testTimeout: budget(10_000) });
 
 for (const conflictFirst of [true, false])
   it(`retains one real fixture child over authenticated relay after conflicts (conflict first=${conflictFirst})`, async () => {

--- a/tests/singleton-migration.test.ts
+++ b/tests/singleton-migration.test.ts
@@ -1,4 +1,6 @@
 import { randomBytes } from 'node:crypto';
+import { once } from 'node:events';
+import { budget } from './helpers/timing.js';
 import { privateFixtureDirectory } from './helpers/private-directory.js';
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
@@ -26,15 +28,14 @@ it('blocks coexistence and waits for a verified legacy host and its owned child 
  let stopping=false;const stop=()=>{if(stopping)return;stopping=true;server.close();owned.kill();process.disconnect();};
  process.on('message',stop);
  const server=net.createServer(s=>s.on('data',chunk=>{const r=JSON.parse(chunk);s.end(JSON.stringify({id:r.id,ok:true,result:r.method==='status'?{pid:process.pid,socketPath:${JSON.stringify(socket)},protocolVersion:1,servers:[]}:true}));if(r.method==='stop')setTimeout(stop,250);}));
- server.listen(${JSON.stringify(socket)},()=>fs.writeFileSync(${JSON.stringify(metadata)},JSON.stringify({pid:process.pid,socketPath:${JSON.stringify(socket)}}),{mode:384}));`,
+ server.listen(${JSON.stringify(socket)},()=>{fs.writeFileSync(${JSON.stringify(metadata)},JSON.stringify({pid:process.pid,socketPath:${JSON.stringify(socket)}}),{mode:384});process.send('ready');});`,
     ],
     { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] }
   );
   try {
-    for (let i = 0; i < 100; i++) {
-      if (await fs.stat(metadata).catch(() => undefined)) break;
-      await new Promise((r) => setTimeout(r, 10));
-    }
+    // File existence can precede the child finishing its metadata write.
+    const [message] = await once(child, 'message', { signal: AbortSignal.timeout(budget(5_000)) });
+    expect(message).toBe('ready');
     expect(await legacyDaemons()).toEqual([{ pid: child.pid, socketPath: socket, verified: true }]);
     if (process.platform !== 'win32') expect((await fs.stat(daemonRunDir())).mode & 0o7777).toBe(0o755);
     await expect(assertLegacyDrained()).rejects.toMatchObject({ code: 'legacy_daemon_conflict' });


### PR DESCRIPTION
The singleton daemon fixtures have two readiness/timing races: the Chrome-relay case can exceed the global ten-second timeout on Windows, and the migration fixture can observe a metadata file before the child finishes writing its JSON.

Use the existing platform-scaled test budget for the relay file and wait for the migration child's bounded IPC readiness message after its metadata write. Production behavior and timeouts are unchanged.

Validation: `pnpm check`; full `pnpm test` (217 files, 1,861 tests passed); focused real relay fixture cases; built CLI list/call against a synthetic loopback MCP server. Independent local autoreview through P2 is clean. The original Windows failure is https://github.com/openclaw/mcporter/actions/runs/33986588630; the migration race was reproduced locally as an empty JSON read.
