### PR TITLE
fix(generate): preserve explicit definitions when config is supplied

### DIFF
--- a/src/cli/generate/definition.ts
+++ b/src/cli/generate/definition.ts
@@ -131,7 +131,7 @@ export async function fetchTools(
   const base = await createRuntime({
     configPath,
     rootDir,
-    servers: configPath ? undefined : [definition],
+    servers: [definition],
   });
   const { createGeneratedKeepAliveRuntime } = await import('../../generated-daemon-runtime.js');
   const context = await createGeneratedKeepAliveRuntime(base, definition);

--- a/tests/singleton-discovery.test.ts
+++ b/tests/singleton-discovery.test.ts
@@ -83,3 +83,23 @@ it('refuses raw/interactive pooled bypasses while preserving ephemeral connectio
     await f.close();
   }
 });
+
+it.each([false, true])('preserves explicit ephemeral discovery with config (same-name entry=%s)', async (conflict) => {
+  const f = await singletonFixture();
+  try {
+    const configPath = path.join(f.root, 'discovery.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        imports: [],
+        mcpServers: conflict ? { fixture: { command: process.execPath, args: ['-e', 'process.exit(1)'] } } : {},
+      })
+    );
+    const definition = { ...f.definition, lifecycle: { mode: 'ephemeral' as const }, allowedTools: ['identity'] };
+    const discovered = await fetchTools(definition, 'fixture', configPath);
+    expect(discovered.tools.map((tool) => tool.name)).toEqual(['identity']);
+    expect(discovered.derivedDescription).toBe('Operate the synthetic fixture.');
+  } finally {
+    await f.close();
+  }
+});


### PR DESCRIPTION
`mcporter --config config.json generate-cli --command <url>` discarded the explicit server definition during tool discovery. An empty config failed with “Unknown MCP server”; a conflicting same-name entry could connect to a different server from the one embedded in the generated CLI.

Always construct discovery from the already resolved definition, preserving its tool filters and metadata. The regression cases cover empty and conflicting configs using a real MCP fixture.

Restacked onto main after #348, #344, and #347 landed. This PR now contains only the code fix and regression tests. The complete 0.13.10 Unreleased section is carried by #349.
