### PR TITLE
fix(daemon): surface detached launch failures to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [0.13.10] - Unreleased
 
-- Report detached daemon launch failures with the executable and OS error instead of crashing the parent CLI or waiting for a readiness timeout. (PR #347, thanks @SebTardif)
+### Daemon
+
+- Report detached daemon launch failures with the executable and OS error instead of crashing the parent CLI or waiting for a readiness timeout. (PRs #347 and #351, thanks @SebTardif)
 
 ## [0.13.9] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.13.10] - Unreleased
 
-- Handle detached daemon spawn errors so a missing launch command reaches the normal startup failure path instead of crashing the parent CLI. (PR #347, thanks @SebTardif)
+- Report detached daemon launch failures with the executable and OS error instead of crashing the parent CLI or waiting for a readiness timeout. (PR #347, thanks @SebTardif)
 
 ## [0.13.9] - 2026-09-05
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -25,6 +25,8 @@ mcporter daemon restart
 mcporter daemon migrate
 ```
 
+Explicit starts and automatic launches report process creation failures immediately with the executable and OS error. After a successful spawn, clients wait up to 45 seconds for authenticated daemon readiness; a timeout includes `mcporter daemon start --foreground --log` guidance for diagnosing startup.
+
 Status describes the global host. JSON includes `pid`, `protocolVersion`, `generation`, `views`, and `servers`. Each connection has a non-secret `connectionId`, `connectionGeneration`, `connected`, `activeCalls`, and `lastUsedAt`. `browserOwner`, when present, identifies its connection and state. Opaque connection identifiers deliberately do not reveal environment values, credentials, child arguments, or URLs. The socket is mode 0600 in an owner-only mode 0700 directory. Windows uses a user/namespace-specific named pipe and a protected, verified current-user-only directory ACL. Both platforms authenticate the host and client with fresh, connection-bound HMAC challenges before transmitting resolved configuration. An impostor listener cannot obtain the configuration. No key is sent over the socket or pipe.
 
 `stop` drains admission and refuses to close while calls remain active. Retry stop after those calls finish. Ordinary clients never request a shared server restart in response to a failed call. Protocol errors, daemon-generation changes, and expired handles are returned to the caller; an uncertain request is not replayed against a replacement host.

--- a/src/cli/daemon-command.ts
+++ b/src/cli/daemon-command.ts
@@ -126,7 +126,7 @@ async function handleDaemonStart(args: string[], options: DaemonCliOptions, clie
     forwardedArgs.push('--log-servers', Array.from(logging.serverFilter).join(','));
   }
 
-  launchDaemonDetached({
+  await launchDaemonDetached({
     configPath: options.configPath,
     configExplicit: options.configExplicit,
     rootDir: options.rootDir,

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -216,7 +216,7 @@ export class DaemonClient {
       );
     this.startingPromise ??= (async () => {
       const { launchDaemonDetached } = await import('./launch.js');
-      launchDaemonDetached({
+      await launchDaemonDetached({
         configPath: this.options.configPath,
         metadataPath: this.metadataPath,
         socketPath: this.socketPath,

--- a/src/daemon/launch.ts
+++ b/src/daemon/launch.ts
@@ -26,15 +26,24 @@ interface DaemonLaunchInvocation {
   readonly env: NodeJS.ProcessEnv;
 }
 
-export function launchDaemonDetached(options: DaemonLaunchOptions, launch: typeof spawn = spawn): void {
+export async function launchDaemonDetached(options: DaemonLaunchOptions, launch: typeof spawn = spawn): Promise<void> {
   const invocation = buildDaemonLaunchInvocation(options);
-  const child = launch(invocation.command, invocation.args, {
-    detached: true,
-    stdio: 'ignore',
-    env: invocation.env,
-  });
-  child.on('error', () => {}); // swallow ENOENT when the launch command is missing
-  child.unref();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = launch(invocation.command, invocation.args, {
+        detached: true,
+        stdio: 'ignore',
+        env: invocation.env,
+      });
+      // Keep handling late errors after spawn; readiness is checked by the caller.
+      child.on('error', reject);
+      child.once('spawn', resolve);
+      child.unref();
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to start MCPorter daemon (${invocation.command}): ${message}`, { cause: error });
+  }
 }
 
 export function buildDaemonLaunchInvocation(

--- a/tests/daemon-launch-process.integration.test.ts
+++ b/tests/daemon-launch-process.integration.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { ensureDistBuilt } from './helpers/dist.js';
+import { privateFixtureDirectory } from './helpers/private-directory.js';
 import { budget } from './helpers/timing.js';
 
 const runNode = promisify(execFile);
@@ -16,33 +17,75 @@ beforeAll(async () => {
 });
 
 describe('detached daemon spawn failures in a real process', () => {
-  it('survives an asynchronous ENOENT from the launch command', async () => {
+  it('returns an asynchronous ENOENT from the launch command to the caller', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcporter-daemon-launch-error-'));
     try {
       const script = `
+        import assert from 'node:assert/strict';
         import { spawn } from 'node:child_process';
         import { launchDaemonDetached } from ${JSON.stringify(launchModule.href)};
-        const keepAlive = setTimeout(() => {}, 10_000);
-        let child;
-        launchDaemonDetached({
+        let closed;
+        const launched = launchDaemonDetached({
           configPath: ${JSON.stringify(path.join(tempDir, 'config.json'))},
           socketPath: ${JSON.stringify(path.join(tempDir, 'daemon.sock'))},
           metadataPath: ${JSON.stringify(path.join(tempDir, 'daemon.json'))},
         }, (_command, args, options) => {
-          child = spawn(${JSON.stringify(path.join(tempDir, 'missing-daemon'))}, args, options);
+          const child = spawn(${JSON.stringify(path.join(tempDir, 'missing-daemon'))}, args, options);
+          closed = new Promise(resolve => child.once('close', resolve));
           return child;
         });
         // Do not register an error listener here: production must handle it.
-        await new Promise(resolve => child.once('close', resolve));
-        clearTimeout(keepAlive);
-        console.log('survived daemon spawn failure');
+        await assert.rejects(launched, error => {
+          assert.match(error.message, /Failed to start MCPorter daemon.*ENOENT/);
+          assert.ok(error.cause instanceof Error);
+          assert.equal(error.cause.code, 'ENOENT');
+          return true;
+        });
+        await closed;
+        console.log('reported daemon spawn failure');
       `;
       const scriptPath = path.join(tempDir, 'proof.mjs');
       await fs.writeFile(scriptPath, script);
       const { stdout, stderr } = await runNode(process.execPath, [scriptPath], {
         timeout: budget(10_000),
       });
-      expect(stdout.trim()).toBe('survived daemon spawn failure');
+      expect(stdout.trim()).toBe('reported daemon spawn failure');
+      expect(stderr).toBe('');
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(['daemon start', 'auto-launch'] as const)('reports the real spawn error from %s', async (mode) => {
+    const tempDir = await privateFixtureDirectory('mcp-launch-');
+    try {
+      const missingCommand = path.join(tempDir, 'missing-daemon');
+      const script = `
+        import assert from 'node:assert/strict';
+        import { handleDaemonCli } from ${JSON.stringify(new URL('../dist/cli/daemon-command.js', import.meta.url).href)};
+        import { DaemonClient } from ${JSON.stringify(new URL('../dist/daemon/client.js', import.meta.url).href)};
+        const options = { configPath: ${JSON.stringify(path.join(tempDir, 'config.json'))} };
+        // Use a genuinely missing executable without mocking launch or readiness.
+        Object.defineProperty(process, 'execPath', { value: ${JSON.stringify(missingCommand)} });
+        const start = ${JSON.stringify(mode)} === 'daemon start'
+          ? () => handleDaemonCli(['start'], options)
+          : () => new DaemonClient(options).ensureDaemon();
+        await assert.rejects(start, error => {
+          assert.match(error.message, /Failed to start MCPorter daemon.*missing-daemon.*ENOENT/);
+          assert.ok(error.cause instanceof Error);
+          assert.equal(error.cause.code, 'ENOENT');
+          assert.equal(error.cause.path, ${JSON.stringify(missingCommand)});
+          return true;
+        });
+        console.log('reported daemon spawn failure');
+      `;
+      const scriptPath = path.join(tempDir, 'proof.mjs');
+      await fs.writeFile(scriptPath, script);
+      const { stdout, stderr } = await runNode(process.execPath, [scriptPath], {
+        env: { ...process.env, MCPORTER_DAEMON_DIR: tempDir, MCPORTER_DAEMON_CHILD: '0' },
+        timeout: budget(10_000),
+      });
+      expect(stdout.trim()).toBe('reported daemon spawn failure');
       expect(stderr).toBe('');
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/tests/daemon-launch.test.ts
+++ b/tests/daemon-launch.test.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess, spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
@@ -12,35 +13,60 @@ const options: DaemonLaunchOptions = {
   extraArgs: ['--log-file', '/tmp/mcporter/daemon.log'],
 };
 
-describe('buildDaemonLaunchInvocation', () => {
-  it('spawns and unreferences the detached daemon', () => {
-    const child = new EventEmitter() as EventEmitter & { unref: () => void };
-    child.unref = vi.fn();
-    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+describe('launchDaemonDetached', () => {
+  it('waits for spawn and unreferences the detached daemon without waiting for exit', async () => {
+    const child = new EventEmitter() as ChildProcess;
+    const unref = vi.fn();
+    child.unref = unref;
+    const launch = vi.fn(() => child);
+    const settled = vi.fn();
 
-    launchDaemonDetached(options, launch as unknown as typeof import('node:child_process').spawn);
+    const launched = launchDaemonDetached(options, launch as typeof spawn).then(settled);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(settled).not.toHaveBeenCalled();
+    child.emit('spawn');
+    await launched;
 
     expect(launch).toHaveBeenCalledWith(
       process.execPath,
       expect.arrayContaining(['daemon', 'start', '--foreground']),
       expect.objectContaining({ detached: true, stdio: 'ignore' })
     );
-    expect(child.unref).toHaveBeenCalled();
+    expect(unref).toHaveBeenCalled();
+    expect(settled).toHaveBeenCalledOnce();
+    expect(() => child.emit('error', new Error('late child error'))).not.toThrow();
+    expect(() => child.emit('error', new Error('another late child error'))).not.toThrow();
+    await expect(launched).resolves.toBeUndefined();
   });
 
-  it('attaches an error listener before unref so spawn failures stay handled', () => {
-    const child = new EventEmitter() as EventEmitter & { unref: () => void };
-    child.unref = vi.fn(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' })));
-    const launch = vi.fn(() => child as unknown as ReturnType<typeof import('node:child_process').spawn>);
+  it.each(['ENOENT', 'EACCES'])('reports %s with the launch command and original cause', async (code) => {
+    const child = new EventEmitter() as ChildProcess;
+    const error = Object.assign(new Error(code), { code });
+    const unref = vi.fn(() => child.emit('error', error));
+    child.unref = unref;
+    const launch = vi.fn(() => child);
 
-    expect(() =>
-      launchDaemonDetached(options, launch as unknown as typeof import('node:child_process').spawn)
-    ).not.toThrow();
-    expect(child.listenerCount('error')).toBeGreaterThan(0);
-    expect(() => child.emit('error', Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))).not.toThrow();
-    expect(child.unref).toHaveBeenCalled();
+    await expect(launchDaemonDetached(options, launch as typeof spawn)).rejects.toMatchObject({
+      message: `Failed to start MCPorter daemon (${process.execPath}): ${code}`,
+      cause: error,
+    });
+    expect(() => child.emit('error', error)).not.toThrow();
+    expect(unref).toHaveBeenCalled();
   });
 
+  it('reports synchronous spawn failures through the same rejection path', async () => {
+    const error = new Error('spawn failed');
+    const launch = vi.fn(() => {
+      throw error;
+    });
+    await expect(launchDaemonDetached(options, launch)).rejects.toMatchObject({
+      message: `Failed to start MCPorter daemon (${process.execPath}): spawn failed`,
+      cause: error,
+    });
+  });
+});
+
+describe('buildDaemonLaunchInvocation', () => {
   it('launches Node entrypoints directly with the CLI script path', () => {
     const invocation = buildDaemonLaunchInvocation(options, {
       argvEntry: '/repo/dist/cli.js',


### PR DESCRIPTION
Supersedes #347, keeping @SebTardif's original commit and sign-off at the base of this branch.

## Problem

`launchDaemonDetached` spawned the daemon with `{ detached: true, stdio: 'ignore' }` and called `unref()` without an `error` listener. Node emits spawn failures (ENOENT and friends) asynchronously, so a missing launch command — stripped PATH, missing `nohup` on a compiled macOS binary, a deleted Node entry — became an unhandled `'error'` event that killed the parent CLI. This is the same defect class as #341 for `openExternal`.

## What changed beyond the original fix

@SebTardif's commit attached the listener, which stopped the crash but swallowed the cause: callers then sat through the full readiness timeout with no indication of what failed.

`launchDaemonDetached` now awaits process creation and resolves on `'spawn'` or rejects on `'error'`, wrapping the failure with the executable and the original OS error as `cause`. Both call sites — `mcporter daemon start` and `DaemonClient.ensureDaemon()` auto-launch — await it, so a launch failure is reported immediately instead of masquerading as a readiness timeout. The `'error'` listener stays attached after a successful spawn so a late error still cannot become an unhandled event.

Authenticated readiness, its 45-second timeout, the foreground logging guidance, and the 0.13.9 single-user ownership safeguards are unchanged. Other daemon and relay spawn sites were checked and already handle errors.

## Verification

`pnpm check` clean. `pnpm test`: 1867 passed, 26 existing skips, 218 files. New tests cover real ENOENT failures through both callers, spawn ordering, and repeated late errors. No timeouts, CI budgets, or skips were changed.
